### PR TITLE
Support algorithm NONE when using the Authorization Code Flow

### DIFF
--- a/src/jose/apr_jwt.c
+++ b/src/jose/apr_jwt.c
@@ -336,7 +336,7 @@ apr_byte_t apr_jwt_parse(apr_pool_t *pool, const char *s_json,
 		return FALSE;
 	}
 
-	if (unpacked->nelts > 2) {
+	if (unpacked->nelts > 2 && strcmp(jwt->header.alg, "none") != 0) {
 		/* remainder is the signature */
 		if (apr_jwt_parse_signature(pool, ((const char**) unpacked->elts)[2],
 				&jwt->signature) == FALSE) {

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -775,7 +775,7 @@ static int oidc_handle_authorization_response(request_rec *r, oidc_cfg *c,
 	/* parse and validate the obtained id_token */
 	if (id_token != NULL) {
 		if (oidc_proto_parse_idtoken(r, c, provider, id_token,
-				proto_state->nonce, &remoteUser, &jwt) == FALSE) {
+				proto_state->nonce, &remoteUser, &jwt, FALSE) == FALSE) {
 			ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
 					"oidc_handle_authorization_response: could not parse or verify the id_token contents, return HTTP_UNAUTHORIZED");
 			return HTTP_UNAUTHORIZED;
@@ -832,7 +832,7 @@ static int oidc_handle_authorization_response(request_rec *r, oidc_cfg *c,
 		/* if we had no id_token yet, we must have one now (by flow) */
 		if (jwt == NULL) {
 			if (oidc_proto_parse_idtoken(r, c, provider, id_token, nonce,
-					&remoteUser, &jwt) == FALSE) {
+					&remoteUser, &jwt, TRUE) == FALSE) {
 				ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
 						"oidc_handle_authorization_response: could not parse or verify the id_token contents, return HTTP_UNAUTHORIZED");
 				return HTTP_UNAUTHORIZED;

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -245,7 +245,7 @@ apr_byte_t oidc_proto_check_token_type(request_rec *r, oidc_provider_t *provider
 apr_byte_t oidc_proto_resolve_code(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, const char *code, char **s_id_token, char **s_access_token, char **s_token_type);
 apr_byte_t oidc_proto_resolve_userinfo(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, const char *access_token, const char **response, json_t **claims);
 apr_byte_t oidc_proto_account_based_discovery(request_rec *r, oidc_cfg *cfg, const char *acct, char **issuer);
-apr_byte_t oidc_proto_parse_idtoken(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, const char *id_token, const char *nonce, char **user, apr_jwt_t **jwt);
+apr_byte_t oidc_proto_parse_idtoken(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, const char *id_token, const char *nonce, char **user, apr_jwt_t **jwt, apr_byte_t is_code_flow);
 apr_byte_t oidc_proto_validate_access_token(request_rec *r, oidc_provider_t *provider, apr_jwt_t *jwt, const char *response_type, const char *access_token, const char *token_type);
 apr_byte_t oidc_proto_validate_code(request_rec *r, oidc_provider_t *provider, apr_jwt_t *jwt, const char *response_type, const char *code);
 int oidc_proto_javascript_implicit(request_rec *r, oidc_cfg *c);

--- a/test/test.c
+++ b/test/test.c
@@ -156,6 +156,26 @@ static char *test_jwt_parse(apr_pool_t *pool) {
 	return 0;
 }
 
+static char *test_plaintext_jwt_parse(apr_pool_t *pool) {
+
+	// from http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-20
+	// 6.1.  Example Plaintext JWT
+	char *s = apr_pstrdup(pool,
+			"eyJhbGciOiJub25lIn0" \
+			".eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ" \
+			".");
+
+	apr_jwt_t *jwt = NULL;
+	TST_ASSERT("apr_jwt_parse", apr_jwt_parse(pool, s, &jwt, NULL, NULL));
+
+	TST_ASSERT_STR("header.alg", jwt->header.alg, "none");
+
+	TST_ASSERT_STR("payload.iss", jwt->payload.iss, "joe");
+	TST_ASSERT_LONG("payload.exp", (long)apr_time_sec(jwt->payload.exp), 1300819380L);
+
+	return 0;
+}
+
 static char *test_jwt_get_string(apr_pool_t *pool) {
 	//apr_jwt_get_string
 
@@ -240,6 +260,7 @@ static char * all_tests(apr_pool_t *pool) {
 	TST_RUN(test_jwt_url_encode_decode, pool);
 	TST_RUN(test_jwt_header_to_string, pool);
 	TST_RUN(test_jwt_parse, pool);
+	TST_RUN(test_plaintext_jwt_parse, pool);
 	TST_RUN(test_jwt_get_string, pool);
 
 	TST_RUN(test_jwk_parse_json, pool);


### PR DESCRIPTION
Currently, ID Token signed using the algorithm NONE(Plaintext JWT) is not supported in mod_auth_openidc.
The spec says it is possible to use "none" as the "alg"  when using the Authorization Code Flow.

Please refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken

```
ID Tokens MUST NOT use none as the alg value unless the Response Type used returns no ID Token
from the Authorization Endpoint (such as when using the Authorization Code Flow) and the Client
explicitly requested the use of none at Registration time.
```
