### PR TITLE
  Fix big endian issue #18.

### DIFF
--- a/src/jose/apr_jwe.c
+++ b/src/jose/apr_jwe.c
@@ -371,6 +371,8 @@ apr_byte_t apr_jwe_decrypt_jwt(apr_pool_t *pool, apr_jwt_header_t *header,
 		// little endian machine: reverse AAD length for big endian representation
 		for (i=0; i < sizeof(int64_t); ++i) p[sizeof(uint64_t)-1-i] = src[i];
 	}
+	else
+		memcpy(p, &al, sizeof(uint64_t));
 
 //	uint64_t big_endian = htobe64(al);
 //	memcpy(p, &big_endian, sizeof(int64_t));

--- a/test/test.c
+++ b/test/test.c
@@ -243,7 +243,7 @@ static char * all_tests(apr_pool_t *pool) {
 	TST_RUN(test_jwt_get_string, pool);
 
 	TST_RUN(test_jwk_parse_json, pool);
-	//TST_RUN(test_jwt_decryption, pool);
+	TST_RUN(test_jwt_decryption, pool);
 
 	return 0;
 }


### PR DESCRIPTION
- For big endian, p does not get info about
  Additional Authentication Data length (al).
- Run test_jwt_decryption.
