### PR TITLE
Added a check in proto.c to use the introspection token only when the…

### DIFF
--- a/src/proto.c
+++ b/src/proto.c
@@ -1860,7 +1860,8 @@ apr_byte_t oidc_proto_token_endpoint_auth(request_rec *r, oidc_cfg *cfg,
 		const char *client_secret, const char *audience, apr_table_t *params,
 		char **basic_auth_str, char **bearer_auth_str) {
 
-	if (cfg->oauth.introspection_client_auth_bearer_token != NULL)
+	if (cfg->oauth.introspection_client_auth_bearer_token != NULL &&
+			(strcmp(cfg->oauth.introspection_endpoint_url, audience) == 0))
 		return oidc_proto_endpoint_access_token_bearer(r, cfg, params,
 				bearer_auth_str);
 


### PR DESCRIPTION
… introspection endpoint is called and not for anything else.

I am sorry I forgot to add this and introduced a bug:
- if OIDCOAuthIntrospectionClientAuthBearerToken is set, the will bypass defined authorization for all endpoints, not just for introspection
- this means that the default behavior is disrupted: the client cannot authorize anymore with the OP in OIDC context.

Do you have a better method of checking if the `oidc_proto_token_endpoint_auth` method is called from oauth for introspection?

I am kind of late for the 2.3.3 release as well.
