### PR TITLE
Accept basic password with oauth2 token

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -382,8 +382,9 @@
 # "post" :   an HTTP Post parameter called "access_token"
 # "query" :  as an HTTP query parameter called "access_token"
 # "cookie" : as a cookie header called "PA.global" or using the name specified after ":"
+# "basic":   as a HTTP Basic Auth (RFC2617, section 2) password, with any username
 # When not defined the default "header" is used.
-#OIDCOAuthAcceptTokenAs [header|post|query|cookie[:<cookie-name>]+
+#OIDCOAuthAcceptTokenAs [header|post|query|cookie[:<cookie-name>|basic]+
 
 ########################################################################################
 #

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -144,6 +144,8 @@ APLOG_USE_MODULE(auth_openidc);
 #define OIDC_OAUTH_ACCEPT_TOKEN_IN_QUERY   4
 /* accept bearer token as a cookie parameter (PingAccess) */
 #define OIDC_OAUTH_ACCEPT_TOKEN_IN_COOKIE  8
+/* accept bearer token as basic auth password (non-oauth clients) */
+#define OIDC_OAUTH_ACCEPT_TOKEN_IN_BASIC   16
 
 /* the hash key of the cookie name value in the list of options */
 #define OIDC_OAUTH_ACCEPT_TOKEN_IN_OPTION_COOKIE_NAME "cookie-name"
@@ -494,6 +496,7 @@ apr_byte_t oidc_oauth_get_bearer_token(request_rec *r, const char **access_token
 #define OIDC_PROTO_ENDPOINT_AUTH_NONE  "none"
 
 #define OIDC_PROTO_BEARER  "Bearer"
+#define OIDC_PROTO_BASIC   "Basic"
 
 #define OIDC_CLAIM_ISS             "iss"
 #define OIDC_CLAIM_AUD             "aud"
@@ -841,5 +844,7 @@ void oidc_session_set_check_session_iframe(request_rec *r, oidc_session_t *z, co
 const char * oidc_session_get_check_session_iframe(request_rec *r, oidc_session_t *z);
 void oidc_session_set_logout_endpoint(request_rec *r, oidc_session_t *z, const char *logout_endpoint);
 const char * oidc_session_get_logout_endpoint(request_rec *r, oidc_session_t *z);
+
+char *oidc_parse_base64(apr_pool_t *pool, const char *input, char **output, int *output_len);
 
 #endif /* MOD_AUTH_OPENIDC_H_ */

--- a/src/parse.c
+++ b/src/parse.c
@@ -541,7 +541,7 @@ const char *oidc_parse_session_max_duration(apr_pool_t *pool, const char *arg,
 /*
  * parse a base64 encoded binary value from the provided string
  */
-static char *oidc_parse_base64(apr_pool_t *pool, const char *input,
+char *oidc_parse_base64(apr_pool_t *pool, const char *input,
 		char **output, int *output_len) {
 	int len = apr_base64_decode_len(input);
 	*output = apr_palloc(pool, len);
@@ -761,6 +761,7 @@ const char *oidc_parse_pass_userinfo_as(apr_pool_t *pool, const char *v1,
 #define OIDC_OAUTH_ACCEPT_TOKEN_IN_POST_STR   "post"
 #define OIDC_OAUTH_ACCEPT_TOKEN_IN_QUERY_STR  "query"
 #define OIDC_OAUTH_ACCEPT_TOKEN_IN_COOKIE_STR "cookie"
+#define OIDC_OAUTH_ACCEPT_TOKEN_IN_BASIC_STR  "basic"
 
 /*
  * convert an "accept OAuth 2.0 token in" byte value to a string representation
@@ -784,6 +785,10 @@ const char *oidc_accept_oauth_token_in2str(apr_pool_t *pool, apr_byte_t v) {
 		options[i] = OIDC_OAUTH_ACCEPT_TOKEN_IN_COOKIE_STR;
 		i++;
 	}
+	if (v & OIDC_OAUTH_ACCEPT_TOKEN_IN_BASIC) {
+		options[i] = OIDC_OAUTH_ACCEPT_TOKEN_IN_BASIC_STR;
+		i++;
+	}
 	return oidc_flatten_list_options(pool, options);
 }
 
@@ -799,6 +804,8 @@ static apr_byte_t oidc_parse_oauth_accept_token_in_str2byte(const char *v) {
 		return OIDC_OAUTH_ACCEPT_TOKEN_IN_QUERY;
 	if (strstr(v, OIDC_OAUTH_ACCEPT_TOKEN_IN_COOKIE_STR) == v)
 		return OIDC_OAUTH_ACCEPT_TOKEN_IN_COOKIE;
+	if (strstr(v, OIDC_OAUTH_ACCEPT_TOKEN_IN_BASIC_STR) == v)
+		return OIDC_OAUTH_ACCEPT_TOKEN_IN_BASIC;
 	return OIDC_OAUTH_ACCEPT_TOKEN_IN_DEFAULT;
 }
 
@@ -815,6 +822,7 @@ const char *oidc_parse_accept_oauth_token_in(apr_pool_t *pool, const char *arg,
 			OIDC_OAUTH_ACCEPT_TOKEN_IN_POST_STR,
 			OIDC_OAUTH_ACCEPT_TOKEN_IN_QUERY_STR,
 			OIDC_OAUTH_ACCEPT_TOKEN_IN_COOKIE_STR,
+			OIDC_OAUTH_ACCEPT_TOKEN_IN_BASIC_STR,
 			NULL };
 	const char *rv = NULL;
 

--- a/test/stub.c
+++ b/test/stub.c
@@ -46,6 +46,10 @@ AP_DECLARE(char *) ap_getword_conf(apr_pool_t *p, const char **line) {
 	return "";
 }
 
+AP_DECLARE(char *) ap_getword_nulls(apr_pool_t *p, const char **line, char stop) {
+	return "";
+}
+
 AP_DECLARE(char *) ap_getword_white(apr_pool_t *p, const char **line) {
 	return 0;
 }


### PR DESCRIPTION
This patch enabled sending an OAuth2 resource server token via Basic
authentication, per RFC 2617, section 2, ignoring the username.

This enables using OAuth2 tokens with clients that only ask for a
username and password and don't support sending a Bearer authentication
header.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>