### PR TITLE
Unset chunked cookies if setting a non-chunked cookie

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,4 +56,5 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Filip Vujicic <https://github.com/FilipVujicic>
 	Janusz Ulanowski <https://github.com/janul>
 	AIMOTO Norihito
+	Andy Lindeman <https://github.com/alindeman>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 10/03/2019
 - improve validation of the post-logout URL parameter on logout; thanks AIMOTO Norihito; closes #449
 - release 2.4.0.3
+- clear any existing chunked cookies when setting a non-chunked cookie; prevents login loops in some scenarios
 
 08/28/2019
 - fixes #447 #441 : changed storing POST params from localStorage to


### PR DESCRIPTION
It's possible to get into a scenario where:
* A previous session needed a chunked cookie
* That previous session is now expired
* mod_auth_openidc starts a new auth request, which is successful
* The new auth request results in a token that does _not_ need a chunked cookie
* mod_auth_openidc only sets the non-chunked cookie, leaving the chunked cookies (including the counter cookie)
* mod_auth_openidc continues using the chunked cookie, because the counter cookie exists, resulting in an infinite auth loop until the user manually clears their cookies

Additionally, to save on request size, unset the non-chunked cookie if we end up setting a chunked cookie.