### PR TITLE
Fix open redirect starting with a slash and backslash

### DIFF
--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -3063,6 +3063,14 @@ static apr_byte_t oidc_validate_post_logout_url(request_rec *r, const char *url,
                                                 url);
                 oidc_error(r, "%s: %s", *err_str, *err_desc);
                 return FALSE;
+        } else if ((uri.hostname == NULL) && (strstr(url, "/\\") == url)) {
+                *err_str = apr_pstrdup(r->pool, "Malformed URL");
+                *err_desc =
+                                apr_psprintf(r->pool,
+                                                "No hostname was parsed and starting with '/\\': %s",
+                                                url);
+                oidc_error(r, "%s: %s", *err_str, *err_desc);
+                return FALSE;
 	}
 
 	/* validate the URL to prevent HTTP header splitting */


### PR DESCRIPTION
Fix open redirect to the following cases.

```
http://rp.example.co.jp/oidc/redirect_uri?logout=/\phishing-site.example.com/logout.html
```

When the response HTTP header is 'Location: /\phishingsite.example.com/logout.html', the browser redirects to 'phishing-site.example.com'