### PR TITLE
Add initial support for SameSite=None on session cookies.

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -482,6 +482,11 @@
 # When not defined the default is Off.
 #OIDCCookieSameSite [On|Off]
 
+# Defines whether the SameSite flag will be set to None on the session cookie.
+# When On, the session cookie will have SameSite=None set. This overrides OIDCCookieSameSite if it's set to On.
+# When not defined the default is Off.
+#OIDCCookieSameSiteNone [On|Off]
+
 # Specify the names of cookies to pickup from the browser and send along on backchannel
 # calls to the OP and AS endpoints. This can be used for load-balancing purposes.
 # When not defined, no such cookies are sent.

--- a/src/config.c
+++ b/src/config.c
@@ -128,6 +128,8 @@
 #define OIDC_DEFAULT_COOKIE_HTTPONLY 1
 /* set Same-Site flag on cookies */
 #define OIDC_DEFAULT_COOKIE_SAME_SITE 0
+/* set Same-Site=None flag on session cookie */
+#define OIDC_DEFAULT_COOKIE_SAME_SITE_NONE 0
 /* default cookie path */
 #define OIDC_DEFAULT_COOKIE_PATH "/"
 /* default OAuth 2.0 introspection token parameter name */
@@ -212,6 +214,7 @@
 #define OIDCDefaultLoggedOutURL                "OIDCDefaultLoggedOutURL"
 #define OIDCCookieHTTPOnly                     "OIDCCookieHTTPOnly"
 #define OIDCCookieSameSite                     "OIDCCookieSameSite"
+#define OIDCCookieSameSiteNone                 "OIDCCookieSameSiteNone"
 #define OIDCOutgoingProxy                      "OIDCOutgoingProxy"
 #define OIDCCryptoPassphrase                   "OIDCCryptoPassphrase"
 #define OIDCClaimDelimiter                     "OIDCClaimDelimiter"
@@ -1212,6 +1215,7 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	c->pass_userinfo_as = OIDC_PASS_USERINFO_AS_CLAIMS;
 	c->cookie_http_only = OIDC_DEFAULT_COOKIE_HTTPONLY;
 	c->cookie_same_site = OIDC_DEFAULT_COOKIE_SAME_SITE;
+	c->cookie_same_site_none = OIDC_DEFAULT_COOKIE_SAME_SITE_NONE;
 
 	c->outgoing_proxy = NULL;
 	c->crypto_passphrase = NULL;
@@ -1647,6 +1651,9 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 	c->cookie_same_site =
 			add->cookie_same_site != OIDC_DEFAULT_COOKIE_SAME_SITE ?
 					add->cookie_same_site : base->cookie_same_site;
+	c->cookie_same_site_none =
+			add->cookie_same_site_none != OIDC_DEFAULT_COOKIE_SAME_SITE_NONE ?
+					add->cookie_same_site_none : base->cookie_same_site_none;
 
 	c->outgoing_proxy =
 			add->outgoing_proxy != NULL ?
@@ -2723,6 +2730,11 @@ const command_rec oidc_config_cmds[] = {
 				(void *) APR_OFFSETOF(oidc_cfg, cookie_same_site),
 				RSRC_CONF,
 				"Defines whether or not the cookie Same-Site flag is set on cookies."),
+		AP_INIT_FLAG(OIDCCookieSameSiteNone,
+				oidc_set_flag_slot,
+				(void *) APR_OFFSETOF(oidc_cfg, cookie_same_site_none),
+				RSRC_CONF,
+				"Defines whether or not the cookie Same-Site flag is set to None on session cookies."),
 		AP_INIT_TAKE1(OIDCOutgoingProxy,
 				oidc_set_string_slot,
 				(void*)APR_OFFSETOF(oidc_cfg, outgoing_proxy),

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -217,6 +217,7 @@ APLOG_USE_MODULE(auth_openidc);
 #define OIDC_USER_INFO_TOKEN_METHOD_HEADER 0
 #define OIDC_USER_INFO_TOKEN_METHOD_POST   1
 
+#define OIDC_COOKIE_EXT_SAME_SITE_NONE   "SameSite=None"
 #define OIDC_COOKIE_EXT_SAME_SITE_LAX    "SameSite=Lax"
 #define OIDC_COOKIE_EXT_SAME_SITE_STRICT "SameSite=Strict"
 
@@ -405,6 +406,7 @@ typedef struct oidc_cfg {
 	int pass_userinfo_as;
 	int cookie_http_only;
 	int cookie_same_site;
+	int cookie_same_site_none;
 
 	char *outgoing_proxy;
 

--- a/src/session.c
+++ b/src/session.c
@@ -222,11 +222,13 @@ static apr_byte_t oidc_session_save_cache(request_rec *r, oidc_session_t *z,
 			/* set the uuid in the cookie */
 			oidc_util_set_cookie(r, oidc_cfg_dir_cookie(r), z->uuid,
 					c->persistent_session_cookie ? z->expiry : -1,
-							c->cookie_same_site ?
-									(first_time ?
-											OIDC_COOKIE_EXT_SAME_SITE_LAX :
-											OIDC_COOKIE_EXT_SAME_SITE_STRICT) :
-											NULL);
+					c->cookie_same_site_none ? 
+						OIDC_COOKIE_EXT_SAME_SITE_NONE :
+						c->cookie_same_site ?
+								(first_time ?
+										OIDC_COOKIE_EXT_SAME_SITE_LAX :
+										OIDC_COOKIE_EXT_SAME_SITE_STRICT) :
+										NULL);
 
 	} else {
 


### PR DESCRIPTION
We have an internal application protected by mod_auth_openidc, which we use inside an `<iframe>` in certain cases. When Chrome 80 is released, cookies will default to `SameSite=Lax` by default, which will break our application since it will prevent `mod_auth_openidc` cookies from being sent when the page is loaded in an `<iframe>`.

https://www.chromestatus.com/feature/5088147346030592

This adds `OIDCCookieSameSiteNone`, which, when enabled, forces the session cookie to `SameSite=None`. This overrides `OIDCCookieSameSite` when enabled.

This does not affect other cookies such as the CSRF token. Our typical use case is to log into the internal application in a standalone tab, and then switch over to a different internal application which then `<iframe>`s the initial internal application -- so only the session cookie needs to be `SameSite=None`. I am open to this affecting all cookies, though.