### PR TITLE
Allow expressions in require statements.

### DIFF
--- a/src/authz.c
+++ b/src/authz.c
@@ -422,10 +422,11 @@ int oidc_authz_worker22(request_rec *r, const json_t * const claims,
  * Apache >=2.4 authorization routine: match the claims from the authenticated user against the Require primitive
  */
 authz_status oidc_authz_worker24(request_rec *r, const json_t * const claims,
-		const char *require_args, oidc_authz_match_claim_fn_type match_claim_fn) {
+		const char *require_args, const void *parsed_require_args, oidc_authz_match_claim_fn_type match_claim_fn) {
 
 	int count_oauth_claims = 0;
-	const char *t, *w;
+	const char *t, *w, *err = NULL;
+	const ap_expr_info_t *expr = parsed_require_args;
 
 	/* needed for anonymous authentication */
 	if (r->user == NULL)
@@ -435,8 +436,13 @@ authz_status oidc_authz_worker24(request_rec *r, const json_t * const claims,
 	if (!claims)
 		return AUTHZ_DENIED;
 
+	t = ap_expr_str_exec(r, expr, &err);
+	if (err) {
+		oidc_error(r, "could not evaluate expression '%s': %s", require_args, err);
+		return AUTHZ_DENIED;
+	}
+
 	/* loop over the Required specifications */
-	t = require_args;
 	while ((w = ap_getword_conf(r->pool, &t)) && w[0]) {
 
 		count_oauth_claims++;

--- a/src/config.c
+++ b/src/config.c
@@ -2326,11 +2326,29 @@ static int oidc_post_config(apr_pool_t *pool, apr_pool_t *p1, apr_pool_t *p2,
 	return oidc_config_check_merged_vhost_configs(pool, s);
 }
 
+static const char *oidc_parse_config(cmd_parms *cmd, const char *require_line,
+		const void **parsed_require_line) {
+	const char *expr_err = NULL;
+	ap_expr_info_t *expr;
+
+	expr = ap_expr_parse_cmd(cmd, require_line, AP_EXPR_FLAG_STRING_RESULT,
+		&expr_err, NULL);
+
+	if (expr_err)
+		return apr_pstrcat(cmd->temp_pool,
+			"Cannot parse expression in require line: ",
+			expr_err, NULL);
+
+	*parsed_require_line = expr;
+
+	return NULL;
+}
+
 #if MODULE_MAGIC_NUMBER_MAJOR >= 20100714
 static const authz_provider oidc_authz_claim_provider = {
 		&oidc_authz_checker_claim,
-		NULL, };
-
+		&oidc_parse_config,
+};
 #ifdef USE_LIBJQ
 static const authz_provider oidc_authz_claims_expr_provider = {
 		&oidc_authz_checker_claims_expr,

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -4043,7 +4043,7 @@ authz_status oidc_authz_checker(request_rec *r, const char *require_args,
 
 	/* dispatch to the >=2.4 specific authz routine */
 	authz_status rc = oidc_authz_worker24(r, claims ? claims : id_token,
-			require_args, match_claim_fn);
+			require_args, parsed_require_args, match_claim_fn);
 
 	/* cleanup */
 	if (claims)

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -667,7 +667,7 @@ apr_byte_t oidc_authz_match_claims_expr(request_rec *r, const char * const attr_
 #if MODULE_MAGIC_NUMBER_MAJOR < 20100714
 int oidc_authz_worker22(request_rec *r, const json_t *const claims, const require_line *const reqs, int nelts);
 #else
-authz_status oidc_authz_worker24(request_rec *r, const json_t * const claims, const char *require_args, oidc_authz_match_claim_fn_type match_claim_fn);
+authz_status oidc_authz_worker24(request_rec *r, const json_t * const claims, const char *require_args, const void *parsed_require_args, oidc_authz_match_claim_fn_type match_claim_fn);
 #endif
 int oidc_oauth_return_www_authenticate(request_rec *r, const char *error, const char *error_description);
 

--- a/test/stub.c
+++ b/test/stub.c
@@ -167,6 +167,18 @@ AP_DECLARE(int) ap_is_initial_req(request_rec *r) {
 	return 0;
 }
 
+AP_DECLARE(ap_expr_info_t *) ap_expr_parse_cmd_mi(const cmd_parms *cmd, const char *expr,
+		unsigned int flags, const char **err, ap_expr_lookup_fn_t *lookup_fn,
+		int module_index) {
+	return NULL;
+}
+
+AP_DECLARE(const char *) ap_expr_str_exec(request_rec *r, const ap_expr_info_t *expr,
+		const char **err) {
+	err = NULL;
+	return expr->filename;
+}
+
 #if MODULE_MAGIC_NUMBER_MAJOR >= 20100714
 AP_DECLARE(void) ap_log_error_(const char *file, int line, int module_index,
 		int level, apr_status_t status, const server_rec *s, const char *fmt,

--- a/test/test.c
+++ b/test/test.c
@@ -1371,6 +1371,8 @@ static char * test_accept(request_rec *r) {
 static char * test_authz_worker(request_rec *r) {
 	authz_status rc;
 	char *require_args = NULL;
+	ap_expr_info_t *parsed_require_args = (ap_expr_info_t *) apr_pcalloc(r->pool,
+		sizeof(ap_expr_info_t));;
 	json_error_t err;
 	json_t *json = NULL;
 	char *claims = NULL;
@@ -1423,47 +1425,58 @@ static char * test_authz_worker(request_rec *r) {
 			json != NULL);
 
 	require_args = "Require claim sub:hans";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (1: simple sub claim)", rc == AUTHZ_DENIED);
 
 	require_args = "Require claim sub:stef";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (2: simple sub claim)", rc == AUTHZ_GRANTED);
 
 	require_args = "Require claim nested.level1.level2:hans";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (3: nested claim)", rc == AUTHZ_GRANTED);
 
 	require_args = "Require claim nested.nestedarray:a";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (4: nested array)", rc == AUTHZ_DENIED);
 
 	require_args = "Require claim nested.nestedarray:c";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (5: nested array)", rc == AUTHZ_GRANTED);
 
 	require_args = "Require claim nested.level1:a";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (6: nested non-string)", rc == AUTHZ_DENIED);
 
 	require_args = "Require claim somebool:a";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (7: non-array)", rc == AUTHZ_DENIED);
 
 	require_args = "Require claim somebool.level1:a";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (8: nested non-array)", rc == AUTHZ_DENIED);
 
 	require_args = "Require claim realm_access.roles:someRole1";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (9: keycloak sample 1)", rc == AUTHZ_GRANTED);
 
 	require_args = "Require claim resource_access.someClient.roles:someRole4";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (10: keycloak sample 2)", rc == AUTHZ_GRANTED);
 
 	require_args = "Require claim https://test.com/pay:alot";
-	rc = oidc_authz_worker24(r, json, require_args, oidc_authz_match_claim);
+	parsed_require_args->filename = require_args;
+	rc = oidc_authz_worker24(r, json, require_args, parsed_require_args, oidc_authz_match_claim);
 	TST_ASSERT("auth status (11: namespaced key)", rc == AUTHZ_GRANTED);
 
 	json_decref(json);


### PR DESCRIPTION
[LocationMatch](https://httpd.apache.org/docs/2.4/mod/core.html#locationmatch) config statements allow regex match groups to be used in `Require` expressions. However, mod_auth_openidc was not parsing these expressions, and instead the raw expression text was used directly. This patch uses existing Apache2 methods to parse and evaluate these expressions. These changes are modeled after the implementation in the Apache2 [ldap](https://github.com/apache/httpd/blob/trunk/modules/aaa/mod_authnz_ldap.c) plugin.

If the expression syntax might cause problems for existing statements, then a config option could be introduced to enable or disable expression parsing in order to not break existing configs. However, it seems unlikely that existing `Require` statements would be misinterpreted after introducing this change.

Unfortunately, this functionality was difficult to test given the requirement to stub the `ap_*` methods that actually perform expression parsing. Because of this, presently the unit tests simply bypass the expression parsing and use the raw `require_args` by hiding the `require_args` in the `parsed_require_args->filename` pointer and directly returning that pointer as the "parsed" expression. I have manually tested these changes using an expression and observed them to work correctly, but unfortunately they're not well-tested by the test suite, and there doesn't appear to be a simple way to do so.