### PR TITLE
Allow configuring which header value is used to calculate the fingerprint of the state during authentication

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+04/25/2020
+- add OIDCStateInputHeaders that allows configuring the header values used to calculate the fingerprint of the state during authentication
+- bump to 2.4.3rc0
+
 03/25/2020
 - oops: fix json_deep_copy of claims
 - release 2.4.2.1

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -823,3 +823,8 @@
 # When not defined no attempt is made to refresh the access token (unless implicitly with OIDCUserInfoRefreshInterval)
 # The optional logout_on_error flag makes the refresh logout the current local session if the refresh fails.
 #OIDCRefreshAccessTokenBeforeExpiry <seconds> [logout_on_error]
+
+# Defines whether the value of the User-Agent and X-Forwarded-For headers will be used as the input
+# for calculating the fingerprint of the state during authentication.
+# When not defined the default "both" is used.
+#OIDCStateInputHeaders [none|user-agent|x-forwarded-for|both]

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mod_auth_openidc],[2.4.2.1],[hans.zandbelt@zmartzone.eu])
+AC_INIT([mod_auth_openidc],[2.4.3rc0],[hans.zandbelt@zmartzone.eu])
 
 AC_SUBST(NAMEVER, AC_PACKAGE_TARNAME()-AC_PACKAGE_VERSION())
 

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -231,6 +231,9 @@ APLOG_USE_MODULE(auth_openidc);
 #define OIDC_TOKEN_BINDING_POLICY_REQUIRED  2
 #define OIDC_TOKEN_BINDING_POLICY_ENFORCED  3
 
+#define OIDC_STATE_INPUT_HEADERS_USER_AGENT 1
+#define OIDC_STATE_INPUT_HEADERS_X_FORWARDED_FOR 2
+
 typedef apr_byte_t (*oidc_proto_pkce_state)(request_rec *r, char **state);
 typedef apr_byte_t (*oidc_proto_pkce_challenge)(request_rec *r, const char *state, char **code_challenge);
 typedef apr_byte_t (*oidc_proto_pkce_verifier)(request_rec *r, const char *state, char **code_verifier);
@@ -416,6 +419,8 @@ typedef struct oidc_cfg {
 	apr_hash_t *info_hook_data;
 	apr_hash_t *black_listed_claims;
 	apr_hash_t *white_listed_claims;
+
+	apr_byte_t state_input_headers;
 
 } oidc_cfg;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1324,3 +1324,36 @@ const char *oidc_parse_refresh_access_token_before_expiry(apr_pool_t *pool,
 	return oidc_parse_int_valid(pool, arg, int_value,
 			oidc_valid_refresh_access_token_before_expiry);
 }
+
+#define OIDC_STATE_INPUT_HEADERS_AS_BOTH            "both"
+#define OIDC_STATE_INPUT_HEADERS_AS_USER_AGENT      "user-agent"
+#define OIDC_STATE_INPUT_HEADERS_AS_X_FORWARDED_FOR "x-forwarded-for"
+#define OIDC_STATE_INPUT_HEADERS_AS_NONE            "none"
+
+/*
+ * parse a "set state input headers as" value from the provided string
+ */
+const char *oidc_parse_set_state_input_headers_as(apr_pool_t *pool, const char *arg,
+		apr_byte_t *state_input_headers) {
+	static char *options[] = {
+			OIDC_STATE_INPUT_HEADERS_AS_BOTH,
+			OIDC_STATE_INPUT_HEADERS_AS_USER_AGENT,
+			OIDC_STATE_INPUT_HEADERS_AS_X_FORWARDED_FOR,
+			OIDC_STATE_INPUT_HEADERS_AS_NONE,
+			NULL };
+	const char *rv = oidc_valid_string_option(pool, arg, options);
+	if (rv != NULL)
+		return rv;
+
+	if (apr_strnatcmp(arg, OIDC_STATE_INPUT_HEADERS_AS_BOTH) == 0) {
+		*state_input_headers = OIDC_STATE_INPUT_HEADERS_USER_AGENT | OIDC_STATE_INPUT_HEADERS_X_FORWARDED_FOR;
+	} else if (apr_strnatcmp(arg, OIDC_STATE_INPUT_HEADERS_AS_USER_AGENT) == 0) {
+		*state_input_headers = OIDC_STATE_INPUT_HEADERS_USER_AGENT;
+	} else if (apr_strnatcmp(arg, OIDC_STATE_INPUT_HEADERS_AS_X_FORWARDED_FOR) == 0) {
+		*state_input_headers = OIDC_STATE_INPUT_HEADERS_X_FORWARDED_FOR;
+	} else if (apr_strnatcmp(arg, OIDC_STATE_INPUT_HEADERS_AS_NONE) == 0) {
+		*state_input_headers = 0;
+	}
+
+	return NULL;
+}

--- a/src/parse.h
+++ b/src/parse.h
@@ -122,6 +122,7 @@ const char *oidc_token_binding_policy2str(apr_pool_t *pool, int v);
 const char *oidc_parse_auth_request_method(apr_pool_t *pool, const char *arg, int *method);
 const char *oidc_parse_max_number_of_state_cookies(apr_pool_t *pool, const char *arg1, const char *arg2, int *int_value, int *bool_value);
 const char *oidc_parse_refresh_access_token_before_expiry(apr_pool_t *pool, const char *arg, int *int_value);
+const char *oidc_parse_set_state_input_headers_as(apr_pool_t *pool, const char *arg, apr_byte_t *state_input_headers);
 
 typedef const char *(*oidc_valid_int_function_t)(apr_pool_t *, int);
 typedef const char *(*oidc_valid_function_t)(apr_pool_t *, const char *);


### PR DESCRIPTION
I added two new options to configure the validation of the `User-Agent` and `X-Forwarded-For` headers during authentication.

Mailing list: https://groups.google.com/forum/#!msg/mod_auth_openidc/iockk1U7UUY/CCMtXwEOAQAJ