### PR TITLE
Add space after cookie-pair;

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+05/02/2020
+- when stripping cookies, add a space between cookies in the resulting header (required by RFC 6265)
+
 04/25/2020
 - add OIDCStateInputHeaders that allows configuring the header values used to calculate the fingerprint of the state during authentication
 - bump to 2.4.3rc0

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -210,7 +210,7 @@ void oidc_strip_cookies(request_rec *r) {
 			}
 
 			if (i == strip->nelts) {
-				result = result ? apr_psprintf(r->pool, "%s%s%s", result,
+				result = result ? apr_psprintf(r->pool, "%s%s %s", result,
 						OIDC_STR_SEMI_COLON, cookie) :
 						cookie;
 			}


### PR DESCRIPTION
[RFC 6265] requires that there be a semicolon and a space between each cookie-pair. Without this change, some particularly strict parsers are not be able to parse the Cookie header after cookie stripping.

[RFC 6265]: https://tools.ietf.org/html/rfc6265#section-4.2