### PR TITLE
Added OIDCValidateIssuer setting to allow disabling of issuer matching.

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -137,6 +137,11 @@
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: ssl_validate_server
 #OIDCSSLValidateServer [On|Off]
 
+# Require configured issuer to match the issuer returned in id_token.
+# (Disable to support Azure AD multi-tenant applications.)
+# When not defined, the default value is "On".
+#OIDCValidateIssuer [On|Off]
+
 # The refresh interval in seconds for the claims obtained from the userinfo endpoint
 # When not defined the default is 0, i.e. the claims are retrieved only at session creation time.
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: userinfo_refresh_interval

--- a/src/config.c
+++ b/src/config.c
@@ -1206,7 +1206,6 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	oidc_cfg_provider_init(&c->provider);
 
 	c->oauth.ssl_validate_server = OIDC_DEFAULT_SSL_VALIDATE_SERVER;
-	c->oauth.validate_issuer = OIDC_DEFAULT_VALIDATE_ISSUER;
 	c->oauth.metadata_url = NULL;
 	c->oauth.client_id = NULL;
 	c->oauth.client_secret = NULL;

--- a/src/config.c
+++ b/src/config.c
@@ -76,6 +76,8 @@
 
 /* validate SSL server certificates by default */
 #define OIDC_DEFAULT_SSL_VALIDATE_SERVER 1
+/* validate issuer by default */
+#define OIDC_DEFAULT_VALIDATE_ISSUER 1
 /* default scope requested from the OP */
 #define OIDC_DEFAULT_SCOPE "openid"
 /* default claim delimiter for multi-valued claims passed in a HTTP header */
@@ -197,6 +199,7 @@
 #define OIDCUserInfoTokenMethod                "OIDCUserInfoTokenMethod"
 #define OIDCTokenBindingPolicy                 "OIDCTokenBindingPolicy"
 #define OIDCSSLValidateServer                  "OIDCSSLValidateServer"
+#define OIDCValidateIssuer                     "OIDCValidateIssuer"
 #define OIDCClientName                         "OIDCClientName"
 #define OIDCClientContact                      "OIDCClientContact"
 #define OIDCScope                              "OIDCScope"
@@ -467,6 +470,21 @@ static const char *oidc_set_ssl_validate_slot(cmd_parms *cmd, void *struct_ptr,
 		rv = ap_set_flag_slot(cmd, cfg, b);
 	return OIDC_CONFIG_DIR_RV(cmd, rv);
 }
+
+/*
+ * set validate issuer slot
+ */
+static const char *oidc_set_validate_issuer_slot(cmd_parms *cmd, void *struct_ptr,
+		const char *arg) {
+	oidc_cfg *cfg = (oidc_cfg *) ap_get_module_config(
+			cmd->server->module_config, &auth_openidc_module);
+	int b = 0;
+	const char *rv = oidc_parse_boolean(cmd->pool, arg, &b);
+	if (rv == NULL)
+		rv = ap_set_flag_slot(cmd, cfg, b);
+	return OIDC_CONFIG_DIR_RV(cmd, rv);
+}
+
 
 /*
  * return the right token endpoint authentication method validation function, based on whether private keys are set
@@ -1144,6 +1162,7 @@ void oidc_cfg_provider_init(oidc_provider_t *provider) {
 	provider->backchannel_logout_supported = OIDC_CONFIG_POS_INT_UNSET;
 
 	provider->ssl_validate_server = OIDC_DEFAULT_SSL_VALIDATE_SERVER;
+	provider->validate_issuer = OIDC_DEFAULT_VALIDATE_ISSUER;
 	provider->client_name = OIDC_DEFAULT_CLIENT_NAME;
 	provider->client_contact = NULL;
 	provider->registration_token = NULL;
@@ -1187,6 +1206,7 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	oidc_cfg_provider_init(&c->provider);
 
 	c->oauth.ssl_validate_server = OIDC_DEFAULT_SSL_VALIDATE_SERVER;
+	c->oauth.validate_issuer = OIDC_DEFAULT_VALIDATE_ISSUER;
 	c->oauth.metadata_url = NULL;
 	c->oauth.client_id = NULL;
 	c->oauth.client_secret = NULL;
@@ -1387,6 +1407,13 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			!= OIDC_DEFAULT_SSL_VALIDATE_SERVER ?
 					add->provider.ssl_validate_server :
 					base->provider.ssl_validate_server;
+
+	c->provider.validate_issuer =
+			add->provider.validate_issuer 
+			!= OIDC_DEFAULT_VALIDATE_ISSUER ?
+					add->provider.validate_issuer :
+					base->provider.validate_issuer;
+
 	c->provider.client_name =
 			apr_strnatcmp(add->provider.client_name, OIDC_DEFAULT_CLIENT_NAME)
 			!= 0 ?
@@ -1478,7 +1505,6 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			!= OIDC_DEFAULT_AUTH_REQUEST_METHOD ?
 					add->provider.auth_request_method :
 					base->provider.auth_request_method;
-
 	c->oauth.ssl_validate_server =
 			add->oauth.ssl_validate_server != OIDC_DEFAULT_SSL_VALIDATE_SERVER ?
 					add->oauth.ssl_validate_server :
@@ -2691,6 +2717,13 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, provider.ssl_validate_server),
 				RSRC_CONF,
 				"Require validation of the OpenID Connect OP SSL server certificate for successful authentication (On or Off)"),
+
+		AP_INIT_TAKE1(OIDCValidateIssuer,
+				oidc_set_validate_issuer_slot,
+				(void*)APR_OFFSETOF(oidc_cfg, provider.validate_issuer),
+				RSRC_CONF,
+				"Require validation of token issuer for successful authentication  (On or Off)"),
+
 		AP_INIT_TAKE1(OIDCClientName,
 				oidc_set_string_slot,
 				(void *) APR_OFFSETOF(oidc_cfg, provider.client_name),
@@ -2893,6 +2926,12 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, oauth.ssl_validate_server),
 				RSRC_CONF,
 				"Require validation of the OAuth 2.0 AS Validation Endpoint SSL server certificate for successful authentication (On or Off)"),
+     		AP_INIT_TAKE1(OIDCValidateIssuer,
+                                oidc_set_validate_issuer_slot,
+                                (void*)APR_OFFSETOF(oidc_cfg, oauth.validate_issuer),
+                                RSRC_CONF,
+                                "Require validation of token issuer for successful authentication (On or Off)"),
+
 		AP_INIT_TAKE123(OIDCOAuthRemoteUserClaim,
 				oidc_set_remote_user_claim,
 				(void*)APR_OFFSETOF(oidc_cfg, oauth.remote_user_claim),

--- a/src/config.c
+++ b/src/config.c
@@ -1504,10 +1504,6 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			!= OIDC_DEFAULT_AUTH_REQUEST_METHOD ?
 					add->provider.auth_request_method :
 					base->provider.auth_request_method;
-	c->oauth.ssl_validate_server =
-			add->oauth.ssl_validate_server != OIDC_DEFAULT_SSL_VALIDATE_SERVER ?
-					add->oauth.ssl_validate_server :
-					base->oauth.ssl_validate_server;
 	c->oauth.metadata_url =
 			add->oauth.metadata_url != NULL ?
 					add->oauth.metadata_url : base->oauth.metadata_url;
@@ -2925,12 +2921,6 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, oauth.ssl_validate_server),
 				RSRC_CONF,
 				"Require validation of the OAuth 2.0 AS Validation Endpoint SSL server certificate for successful authentication (On or Off)"),
-     		AP_INIT_TAKE1(OIDCValidateIssuer,
-                                oidc_set_validate_issuer_slot,
-                                (void*)APR_OFFSETOF(oidc_cfg, oauth.validate_issuer),
-                                RSRC_CONF,
-                                "Require validation of token issuer for successful authentication (On or Off)"),
-
 		AP_INIT_TAKE123(OIDCOAuthRemoteUserClaim,
 				oidc_set_remote_user_claim,
 				(void*)APR_OFFSETOF(oidc_cfg, oauth.remote_user_claim),

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -578,7 +578,7 @@ static apr_byte_t oidc_unsolicited_proto_state(request_rec *r, oidc_cfg *c,
 	/* validate the state JWT, validating optional exp + iat */
 	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, FALSE, FALSE,
 			provider->idtoken_iat_slack,
-			OIDC_TOKEN_BINDING_POLICY_DISABLED) == FALSE) {
+			OIDC_TOKEN_BINDING_POLICY_DISABLED, provider->validate_issuer) == FALSE) {
 		oidc_jwt_destroy(jwt);
 		return FALSE;
 	}
@@ -2919,7 +2919,7 @@ static int oidc_handle_logout_backchannel(request_rec *r, oidc_cfg *cfg) {
 
 	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, FALSE, FALSE,
 			provider->idtoken_iat_slack,
-			OIDC_TOKEN_BINDING_POLICY_DISABLED) == FALSE)
+			OIDC_TOKEN_BINDING_POLICY_DISABLED, provider->validate_issuer) == FALSE)
 		goto out;
 
 	/* verify the "aud" and "azp" values */

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -276,6 +276,7 @@ typedef struct oidc_provider_t {
 
 	// the next ones function as global default settings too
 	int ssl_validate_server;
+        int validate_issuer;
 	char *client_name;
 	char *client_contact;
 	char *registration_token;
@@ -316,6 +317,7 @@ typedef struct oidc_remote_user_claim_t {
 
 typedef struct oidc_oauth_t {
 	int ssl_validate_server;
+	int validate_issuer;
 	char *client_id;
 	char *client_secret;
 	char *metadata_url;
@@ -647,7 +649,7 @@ apr_array_header_t *oidc_proto_supported_flows(apr_pool_t *pool);
 apr_byte_t oidc_proto_flow_is_supported(apr_pool_t *pool, const char *flow);
 apr_byte_t oidc_proto_validate_authorization_response(request_rec *r, const char *response_type, const char *requested_response_mode, char **code, char **id_token, char **access_token, char **token_type, const char *used_response_mode);
 apr_byte_t oidc_proto_jwt_verify(request_rec *r, oidc_cfg *cfg, oidc_jwt_t *jwt, const oidc_jwks_uri_t *jwks_uri, apr_hash_t *symmetric_keys, const char *alg);
-apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt, const char *iss, apr_byte_t exp_is_mandatory, apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy);
+apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt, const char *iss, apr_byte_t exp_is_mandatory, apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy, int validate_issuer);
 apr_byte_t oidc_proto_generate_nonce(request_rec *r, char **nonce, int len);
 apr_byte_t oidc_proto_validate_aud_and_azp(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, oidc_jwt_payload_t *id_token_payload);
 

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -625,7 +625,7 @@ static apr_byte_t oidc_oauth_validate_jwt_access_token(request_rec *r,
 	 * don't enforce anything around iat since it doesn't make much sense for access tokens
 	 */
 	if (oidc_proto_validate_jwt(r, jwt, NULL, FALSE, FALSE, -1,
-			c->oauth.access_token_binding_policy) == FALSE) {
+			c->oauth.access_token_binding_policy, 1) == FALSE) {
 		oidc_jwt_destroy(jwt);
 		return FALSE;
 	}

--- a/src/proto.c
+++ b/src/proto.c
@@ -1297,7 +1297,7 @@ static apr_byte_t oidc_proto_validate_exp(request_rec *r, oidc_jwt_t *jwt,
  */
 apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt,
 		const char *iss, apr_byte_t exp_is_mandatory,
-		apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy) {
+		apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy, int validate_issuer) {
 
 	if (iss != NULL) {
 
@@ -1310,7 +1310,7 @@ apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt,
 		}
 
 		/* check if the issuer matches the requested value */
-		if (oidc_util_issuer_match(iss, jwt->payload.iss) == FALSE) {
+		if (validate_issuer == 1 && oidc_util_issuer_match(iss, jwt->payload.iss) == FALSE) {
 			oidc_error(r,
 					"requested issuer (%s) does not match received \"%s\" value in id_token (%s)",
 					iss, OIDC_CLAIM_ISS, jwt->payload.iss);
@@ -1356,7 +1356,7 @@ static apr_byte_t oidc_proto_validate_idtoken(request_rec *r,
 	/* validate the ID Token JWT, requiring iss match, and valid exp + iat */
 	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, TRUE, TRUE,
 			provider->idtoken_iat_slack,
-			provider->token_binding_policy) == FALSE)
+			provider->token_binding_policy, provider->validate_issuer) == FALSE)
 		return FALSE;
 
 	/* check if the required-by-spec "sub" claim is present */


### PR DESCRIPTION
Added a feature to allow for the disabling of matching issuer returned in id_tokens against the configured issuer value.   This allows mod_auth_openidc to be used for applications with a requirement to use Azure AD in a multi-tenant configuration.   

https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-convert-app-to-be-multi-tenant