### PR TITLE
Added OIDCValidateIssuer configuration setting to allow for Azure AD multi-tenant 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,3 +61,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Paolo Battino
 	absynth76 <https://github.com/absynth76>
 	Aaron Jones <https://github.com/wwaaron>
+	Bryan Ingram <https://github/bcingram>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+05/11/2020
+- added OIDCValidateIssuer to allow for disabling of issuer matching.  helps to support multi-tenant applications.
+
 05/02/2020
 - when stripping cookies, add a space between cookies in the resulting header (required by RFC 6265)
 - move oidc_parse_config inside MODULE_MAGIC_NUMBER_MAJOR to make sure the module compiles with Apache 2.0

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -137,6 +137,11 @@
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: ssl_validate_server
 #OIDCSSLValidateServer [On|Off]
 
+# Require configured issuer to match the issuer returned in id_token.
+# (Disable to support Azure AD multi-tenant applications.)
+# When not defined, the default value is "On".
+#OIDCValidateIssuer [On|Off]
+
 # The refresh interval in seconds for the claims obtained from the userinfo endpoint
 # When not defined the default is 0, i.e. the claims are retrieved only at session creation time.
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: userinfo_refresh_interval

--- a/src/config.c
+++ b/src/config.c
@@ -76,6 +76,8 @@
 
 /* validate SSL server certificates by default */
 #define OIDC_DEFAULT_SSL_VALIDATE_SERVER 1
+/* validate issuer by default */
+#define OIDC_DEFAULT_VALIDATE_ISSUER 1
 /* default scope requested from the OP */
 #define OIDC_DEFAULT_SCOPE "openid"
 /* default claim delimiter for multi-valued claims passed in a HTTP header */
@@ -197,6 +199,7 @@
 #define OIDCUserInfoTokenMethod                "OIDCUserInfoTokenMethod"
 #define OIDCTokenBindingPolicy                 "OIDCTokenBindingPolicy"
 #define OIDCSSLValidateServer                  "OIDCSSLValidateServer"
+#define OIDCValidateIssuer                     "OIDCValidateIssuer"
 #define OIDCClientName                         "OIDCClientName"
 #define OIDCClientContact                      "OIDCClientContact"
 #define OIDCScope                              "OIDCScope"
@@ -458,6 +461,20 @@ static const char *oidc_set_cache_type(cmd_parms *cmd, void *ptr,
  * set SSL validation slot
  */
 static const char *oidc_set_ssl_validate_slot(cmd_parms *cmd, void *struct_ptr,
+		const char *arg) {
+	oidc_cfg *cfg = (oidc_cfg *) ap_get_module_config(
+			cmd->server->module_config, &auth_openidc_module);
+	int b = 0;
+	const char *rv = oidc_parse_boolean(cmd->pool, arg, &b);
+	if (rv == NULL)
+		rv = ap_set_flag_slot(cmd, cfg, b);
+	return OIDC_CONFIG_DIR_RV(cmd, rv);
+}
+
+/*
+ * set validate issuer slot
+ */
+static const char *oidc_set_validate_issuer_slot(cmd_parms *cmd, void *struct_ptr,
 		const char *arg) {
 	oidc_cfg *cfg = (oidc_cfg *) ap_get_module_config(
 			cmd->server->module_config, &auth_openidc_module);
@@ -1144,6 +1161,7 @@ void oidc_cfg_provider_init(oidc_provider_t *provider) {
 	provider->backchannel_logout_supported = OIDC_CONFIG_POS_INT_UNSET;
 
 	provider->ssl_validate_server = OIDC_DEFAULT_SSL_VALIDATE_SERVER;
+	provider->validate_issuer = OIDC_DEFAULT_VALIDATE_ISSUER;
 	provider->client_name = OIDC_DEFAULT_CLIENT_NAME;
 	provider->client_contact = NULL;
 	provider->registration_token = NULL;
@@ -1387,6 +1405,11 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			!= OIDC_DEFAULT_SSL_VALIDATE_SERVER ?
 					add->provider.ssl_validate_server :
 					base->provider.ssl_validate_server;
+	c->provider.validate_issuer =
+			add->provider.validate_issuer
+			!= OIDC_DEFAULT_VALIDATE_ISSUER ?
+					add->provider.validate_issuer :
+					base->provider.validate_issuer;
 	c->provider.client_name =
 			apr_strnatcmp(add->provider.client_name, OIDC_DEFAULT_CLIENT_NAME)
 			!= 0 ?
@@ -2691,6 +2714,11 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, provider.ssl_validate_server),
 				RSRC_CONF,
 				"Require validation of the OpenID Connect OP SSL server certificate for successful authentication (On or Off)"),
+		AP_INIT_TAKE1(OIDCValidateIssuer,
+				oidc_set_validate_issuer_slot,
+				(void*)APR_OFFSETOF(oidc_cfg, provider.validate_issuer),
+				RSRC_CONF,
+				"Require validation of token issuer for successful authentication  (On or Off)"),
 		AP_INIT_TAKE1(OIDCClientName,
 				oidc_set_string_slot,
 				(void *) APR_OFFSETOF(oidc_cfg, provider.client_name),

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -109,6 +109,7 @@ extern module AP_MODULE_DECLARE_DATA auth_openidc_module;
 #define OIDC_METADATA_POST_LOGOUT_REDIRECT_URIS                    "post_logout_redirect_uris"
 #define OIDC_METADATA_IDTOKEN_BINDING_CNF                          "id_token_token_binding_cnf"
 #define OIDC_METADATA_SSL_VALIDATE_SERVER                          "ssl_validate_server"
+#define OIDC_METADATA_VALIDATE_ISSUER                              "validate_issuer"
 #define OIDC_METADATA_SCOPE                                        "scope"
 #define OIDC_METADATA_JWKS_REFRESH_INTERVAL                        "jwks_refresh_interval"
 #define OIDC_METADATA_IDTOKEN_IAT_SLACK                            "idtoken_iat_slack"
@@ -1234,6 +1235,9 @@ apr_byte_t oidc_metadata_conf_parse(request_rec *r, oidc_cfg *cfg,
 	/* find out if we need to perform SSL server certificate validation on the token_endpoint and user_info_endpoint for this provider */
 	oidc_metadata_parse_boolean(r, j_conf, OIDC_METADATA_SSL_VALIDATE_SERVER,
 			&provider->ssl_validate_server, cfg->provider.ssl_validate_server);
+
+	oidc_metadata_parse_boolean(r, j_conf, OIDC_METADATA_VALIDATE_ISSUER,
+			&provider->validate_issuer, cfg->provider.validate_issuer);
 
 	/* find out what scopes we should be requesting from this provider */
 	// TODO: use the provider "scopes_supported" to mix-and-match with what we've configured for the client

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -578,7 +578,7 @@ static apr_byte_t oidc_unsolicited_proto_state(request_rec *r, oidc_cfg *c,
 	/* validate the state JWT, validating optional exp + iat */
 	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, FALSE, FALSE,
 			provider->idtoken_iat_slack,
-			OIDC_TOKEN_BINDING_POLICY_DISABLED) == FALSE) {
+			OIDC_TOKEN_BINDING_POLICY_DISABLED, provider->validate_issuer) == FALSE) {
 		oidc_jwt_destroy(jwt);
 		return FALSE;
 	}
@@ -2919,7 +2919,7 @@ static int oidc_handle_logout_backchannel(request_rec *r, oidc_cfg *cfg) {
 
 	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, FALSE, FALSE,
 			provider->idtoken_iat_slack,
-			OIDC_TOKEN_BINDING_POLICY_DISABLED) == FALSE)
+			OIDC_TOKEN_BINDING_POLICY_DISABLED, provider->validate_issuer) == FALSE)
 		goto out;
 
 	/* verify the "aud" and "azp" values */

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -576,9 +576,9 @@ static apr_byte_t oidc_unsolicited_proto_state(request_rec *r, oidc_cfg *c,
 	}
 
 	/* validate the state JWT, validating optional exp + iat */
-	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, FALSE, FALSE,
+	if (oidc_proto_validate_jwt(r, jwt, provider->validate_issuer ? provider->issuer : NULL, FALSE, FALSE,
 			provider->idtoken_iat_slack,
-			OIDC_TOKEN_BINDING_POLICY_DISABLED, provider->validate_issuer) == FALSE) {
+			OIDC_TOKEN_BINDING_POLICY_DISABLED) == FALSE) {
 		oidc_jwt_destroy(jwt);
 		return FALSE;
 	}
@@ -2916,10 +2916,9 @@ static int oidc_handle_logout_backchannel(request_rec *r, oidc_cfg *cfg) {
 
 	// oidc_proto_validate_idtoken would try and require a token binding cnf
 	// if the policy is set to "required", so don't use that here
-
-	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, FALSE, FALSE,
+	if (oidc_proto_validate_jwt(r, jwt, provider->validate_issuer ? provider->issuer : NULL, FALSE, FALSE,
 			provider->idtoken_iat_slack,
-			OIDC_TOKEN_BINDING_POLICY_DISABLED, provider->validate_issuer) == FALSE)
+			OIDC_TOKEN_BINDING_POLICY_DISABLED) == FALSE)
 		goto out;
 
 	/* verify the "aud" and "azp" values */

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -276,6 +276,7 @@ typedef struct oidc_provider_t {
 
 	// the next ones function as global default settings too
 	int ssl_validate_server;
+        int validate_issuer;
 	char *client_name;
 	char *client_contact;
 	char *registration_token;
@@ -316,6 +317,7 @@ typedef struct oidc_remote_user_claim_t {
 
 typedef struct oidc_oauth_t {
 	int ssl_validate_server;
+	int validate_issuer;
 	char *client_id;
 	char *client_secret;
 	char *metadata_url;
@@ -647,7 +649,7 @@ apr_array_header_t *oidc_proto_supported_flows(apr_pool_t *pool);
 apr_byte_t oidc_proto_flow_is_supported(apr_pool_t *pool, const char *flow);
 apr_byte_t oidc_proto_validate_authorization_response(request_rec *r, const char *response_type, const char *requested_response_mode, char **code, char **id_token, char **access_token, char **token_type, const char *used_response_mode);
 apr_byte_t oidc_proto_jwt_verify(request_rec *r, oidc_cfg *cfg, oidc_jwt_t *jwt, const oidc_jwks_uri_t *jwks_uri, apr_hash_t *symmetric_keys, const char *alg);
-apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt, const char *iss, apr_byte_t exp_is_mandatory, apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy);
+apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt, const char *iss, apr_byte_t exp_is_mandatory, apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy, int validate_issuer);
 apr_byte_t oidc_proto_generate_nonce(request_rec *r, char **nonce, int len);
 apr_byte_t oidc_proto_validate_aud_and_azp(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, oidc_jwt_payload_t *id_token_payload);
 

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -276,7 +276,7 @@ typedef struct oidc_provider_t {
 
 	// the next ones function as global default settings too
 	int ssl_validate_server;
-        int validate_issuer;
+	int validate_issuer;
 	char *client_name;
 	char *client_contact;
 	char *registration_token;
@@ -317,7 +317,6 @@ typedef struct oidc_remote_user_claim_t {
 
 typedef struct oidc_oauth_t {
 	int ssl_validate_server;
-	int validate_issuer;
 	char *client_id;
 	char *client_secret;
 	char *metadata_url;

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -648,7 +648,7 @@ apr_array_header_t *oidc_proto_supported_flows(apr_pool_t *pool);
 apr_byte_t oidc_proto_flow_is_supported(apr_pool_t *pool, const char *flow);
 apr_byte_t oidc_proto_validate_authorization_response(request_rec *r, const char *response_type, const char *requested_response_mode, char **code, char **id_token, char **access_token, char **token_type, const char *used_response_mode);
 apr_byte_t oidc_proto_jwt_verify(request_rec *r, oidc_cfg *cfg, oidc_jwt_t *jwt, const oidc_jwks_uri_t *jwks_uri, apr_hash_t *symmetric_keys, const char *alg);
-apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt, const char *iss, apr_byte_t exp_is_mandatory, apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy, int validate_issuer);
+apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt, const char *iss, apr_byte_t exp_is_mandatory, apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy);
 apr_byte_t oidc_proto_generate_nonce(request_rec *r, char **nonce, int len);
 apr_byte_t oidc_proto_validate_aud_and_azp(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, oidc_jwt_payload_t *id_token_payload);
 

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -625,7 +625,7 @@ static apr_byte_t oidc_oauth_validate_jwt_access_token(request_rec *r,
 	 * don't enforce anything around iat since it doesn't make much sense for access tokens
 	 */
 	if (oidc_proto_validate_jwt(r, jwt, NULL, FALSE, FALSE, -1,
-			c->oauth.access_token_binding_policy, 1) == FALSE) {
+			c->oauth.access_token_binding_policy) == FALSE) {
 		oidc_jwt_destroy(jwt);
 		return FALSE;
 	}

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -625,7 +625,7 @@ static apr_byte_t oidc_oauth_validate_jwt_access_token(request_rec *r,
 	 * don't enforce anything around iat since it doesn't make much sense for access tokens
 	 */
 	if (oidc_proto_validate_jwt(r, jwt, NULL, FALSE, FALSE, -1,
-			c->oauth.access_token_binding_policy) == FALSE) {
+			c->oauth.access_token_binding_policy, 1) == FALSE) {
 		oidc_jwt_destroy(jwt);
 		return FALSE;
 	}

--- a/src/proto.c
+++ b/src/proto.c
@@ -1297,7 +1297,7 @@ static apr_byte_t oidc_proto_validate_exp(request_rec *r, oidc_jwt_t *jwt,
  */
 apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt,
 		const char *iss, apr_byte_t exp_is_mandatory,
-		apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy) {
+		apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy, int validate_issuer) {
 
 	if (iss != NULL) {
 
@@ -1310,7 +1310,7 @@ apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt,
 		}
 
 		/* check if the issuer matches the requested value */
-		if (oidc_util_issuer_match(iss, jwt->payload.iss) == FALSE) {
+		if (validate_issuer == 1 && oidc_util_issuer_match(iss, jwt->payload.iss) == FALSE) {
 			oidc_error(r,
 					"requested issuer (%s) does not match received \"%s\" value in id_token (%s)",
 					iss, OIDC_CLAIM_ISS, jwt->payload.iss);
@@ -1356,7 +1356,7 @@ static apr_byte_t oidc_proto_validate_idtoken(request_rec *r,
 	/* validate the ID Token JWT, requiring iss match, and valid exp + iat */
 	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, TRUE, TRUE,
 			provider->idtoken_iat_slack,
-			provider->token_binding_policy) == FALSE)
+			provider->token_binding_policy, provider->validate_issuer) == FALSE)
 		return FALSE;
 
 	/* check if the required-by-spec "sub" claim is present */

--- a/src/proto.c
+++ b/src/proto.c
@@ -1297,7 +1297,7 @@ static apr_byte_t oidc_proto_validate_exp(request_rec *r, oidc_jwt_t *jwt,
  */
 apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt,
 		const char *iss, apr_byte_t exp_is_mandatory,
-		apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy, int validate_issuer) {
+		apr_byte_t iat_is_mandatory, int iat_slack, int token_binding_policy) {
 
 	if (iss != NULL) {
 
@@ -1310,7 +1310,7 @@ apr_byte_t oidc_proto_validate_jwt(request_rec *r, oidc_jwt_t *jwt,
 		}
 
 		/* check if the issuer matches the requested value */
-		if (validate_issuer == 1 && oidc_util_issuer_match(iss, jwt->payload.iss) == FALSE) {
+		if (oidc_util_issuer_match(iss, jwt->payload.iss) == FALSE) {
 			oidc_error(r,
 					"requested issuer (%s) does not match received \"%s\" value in id_token (%s)",
 					iss, OIDC_CLAIM_ISS, jwt->payload.iss);
@@ -1354,9 +1354,9 @@ static apr_byte_t oidc_proto_validate_idtoken(request_rec *r,
 	}
 
 	/* validate the ID Token JWT, requiring iss match, and valid exp + iat */
-	if (oidc_proto_validate_jwt(r, jwt, provider->issuer, TRUE, TRUE,
+	if (oidc_proto_validate_jwt(r, jwt, provider->validate_issuer ? provider->issuer : NULL, TRUE, TRUE,
 			provider->idtoken_iat_slack,
-			provider->token_binding_policy, provider->validate_issuer) == FALSE)
+			provider->token_binding_policy) == FALSE)
 		return FALSE;
 
 	/* check if the required-by-spec "sub" claim is present */


### PR DESCRIPTION
Simple switch to allow for the disabling of the id_token issuer match validation.   Defaults to "On".  Needed this to support the Azure AD multi-tenant system I'm working on and wanted to contribute a re-usable option for others that need this capability.