### PR TITLE
resource owner password credentials grant

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -237,6 +237,7 @@
 #define OIDCOAuthVerifyCertFiles               "OIDCOAuthVerifyCertFiles"
 #define OIDCOAuthVerifySharedKeys              "OIDCOAuthVerifySharedKeys"
 #define OIDCOAuthVerifyJwksUri                 "OIDCOAuthVerifyJwksUri"
+#define OIDCAuthROPCTokenUri                   "OIDCAuthROPCTokenUri"
 #define OIDCHTTPTimeoutLong                    "OIDCHTTPTimeoutLong"
 #define OIDCHTTPTimeoutShort                   "OIDCHTTPTimeoutShort"
 #define OIDCStateTimeout                       "OIDCStateTimeout"
@@ -1233,6 +1234,7 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	c->oauth.verify_jwks_uri = NULL;
 	c->oauth.verify_public_keys = NULL;
 	c->oauth.verify_shared_keys = NULL;
+	c->oauth.ropc_token_uri = NULL;
 
 	c->oauth.access_token_binding_policy =
 			OIDC_DEFAULT_OAUTH_ACCESS_TOKEN_BINDING_POLICY;
@@ -1593,6 +1595,9 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			add->oauth.verify_shared_keys != NULL ?
 					add->oauth.verify_shared_keys :
 					base->oauth.verify_shared_keys;
+    c->oauth.ropc_token_uri =
+            add->oauth.ropc_token_uri != NULL ?
+                    add->oauth.ropc_token_uri : base->oauth.ropc_token_uri;
 
 	c->oauth.access_token_binding_policy =
 			add->oauth.access_token_binding_policy
@@ -2941,6 +2946,11 @@ const command_rec oidc_config_cmds[] = {
 				(void *)APR_OFFSETOF(oidc_cfg, oauth.verify_jwks_uri),
 				RSRC_CONF,
 				"The JWKs URL on which the Authorization publishes the keys used to sign its JWT access tokens."),
+		AP_INIT_TAKE1(OIDCAuthROPCTokenUri,
+                oidc_set_https_slot,
+                (void *)APR_OFFSETOF(oidc_cfg, oauth.ropc_token_uri),
+                RSRC_CONF,
+                "Endpoint URL on which the resource owner credentials can be exchanged to bearer tokens."),
 
 		AP_INIT_TAKE1(OIDCHTTPTimeoutLong,
 				oidc_set_int_slot,

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -3902,10 +3902,14 @@ static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *c) {
  */
 static int oidc_check_mixed_userid_oauth(request_rec *r, oidc_cfg *c) {
 
-	/* get the bearer access token from the Authorization header */
+	/*
+	 * get the bearer access token from the Authorization header
+	 * alternatively, if provided use the resource owner's credentials to exchange it to a bearer token
+	 */
 	const char *access_token = NULL;
-	if (oidc_oauth_get_bearer_token(r, &access_token) == TRUE)
-		return oidc_oauth_check_userid(r, c, access_token);
+	if (oidc_oauth_get_bearer_token(r, &access_token) == TRUE ||
+        oidc_oauth_convert_auth_to_bearer_token(r, c, &access_token) == TRUE)
+        return oidc_oauth_check_userid(r, c, access_token);
 
 	/* no bearer token found: then treat this as a regular OIDC browser request */
 	return oidc_check_userid_openidc(r, c);

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -336,6 +336,7 @@ typedef struct oidc_oauth_t {
 	char *verify_jwks_uri;
 	apr_hash_t *verify_public_keys;
 	int access_token_binding_policy;
+	char *ropc_token_uri;
 } oidc_oauth_t;
 
 typedef struct oidc_cfg {
@@ -456,6 +457,7 @@ apr_byte_t oidc_get_remote_user(request_rec *r, const char *claim_name, const ch
 // oidc_oauth
 int oidc_oauth_check_userid(request_rec *r, oidc_cfg *c, const char *access_token);
 apr_byte_t oidc_oauth_get_bearer_token(request_rec *r, const char **access_token);
+apr_byte_t oidc_oauth_convert_auth_to_bearer_token(request_rec *r, oidc_cfg *c, const char **access_token);
 
 // oidc_proto.c
 #define OIDC_PROTO_ISS                   "iss"
@@ -798,6 +800,7 @@ char *oidc_util_http_form_encoded_data(request_rec *r, const apr_table_t *params
 #define OIDC_HTTP_HDR_X_REQUESTED_WITH					"X-Requested-With"
 #define OIDC_HTTP_HDR_ACCEPT							"Accept"
 #define OIDC_HTTP_HDR_AUTHORIZATION						"Authorization"
+#define OIDC_HTTP_HDR_RESOURCE_OWNER_AUTHORIZATION      "ResourceOwnerAuthorization"
 #define OIDC_HTTP_HDR_X_FORWARDED_PROTO					"X-Forwarded-Proto"
 #define OIDC_HTTP_HDR_X_FORWARDED_PORT					"X-Forwarded-Port"
 #define OIDC_HTTP_HDR_X_FORWARDED_HOST					"X-Forwarded-Host"
@@ -823,6 +826,7 @@ const char *oidc_util_hdr_in_content_length_get(const request_rec *r);
 const char *oidc_util_hdr_in_x_requested_with_get(const request_rec *r);
 const char *oidc_util_hdr_in_accept_get(const request_rec *r);
 const char *oidc_util_hdr_in_authorization_get(const request_rec *r);
+const char *oidc_util_hdr_in_resource_owner_authorization_get(const request_rec *r);
 const char *oidc_util_hdr_in_x_forwarded_proto_get(const request_rec *r);
 const char *oidc_util_hdr_in_x_forwarded_port_get(const request_rec *r);
 const char *oidc_util_hdr_in_x_forwarded_host_get(const request_rec *r);

--- a/src/util.c
+++ b/src/util.c
@@ -2436,6 +2436,10 @@ const char *oidc_util_hdr_in_authorization_get(const request_rec *r) {
 	return oidc_util_hdr_in_get(r, OIDC_HTTP_HDR_AUTHORIZATION);
 }
 
+const char *oidc_util_hdr_in_resource_owner_authorization_get(const request_rec *r) {
+	return oidc_util_hdr_in_get(r, OIDC_HTTP_HDR_RESOURCE_OWNER_AUTHORIZATION);
+}
+
 const char *oidc_util_hdr_in_x_forwarded_proto_get(const request_rec *r) {
 	return oidc_util_hdr_in_get_left_most_only(r,
 			OIDC_HTTP_HDR_X_FORWARDED_PROTO, OIDC_STR_COMMA OIDC_STR_SPACE);


### PR DESCRIPTION
Tentative patch to discover views on Resource Owner Password Credentials Grant.

I'm aware the grant type is kind of a bastard child. However, it is standard thus supported by modern IAM providers.

The main usecase I see here, would be supporting access using service accounts (which are not SSOd). Why use an SSO protocol then?
I'm also aware the same could be achieved with other authn methods like ldap. However, in our system for example, we also maintain SSOd accounts and so we could make the plunge in consolidating IAM into a single implementation (Keycloak). No need to maintain ldap, extra infrastructure, simplifications across the board - cost benefits would be tangible without compromising security.

I've tested this patch internally and it looks good. In it's current form probably not mergeable anyways. Partly because my C sucks, but also aspects like refresh handling hasn't even been considered. More than happy to keep working on it, if this is of interest.