### PR TITLE
Add OIDCStateCookiePrefix setting for the state cookie prefix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Aaron Jones <https://github.com/wwaaron>
 	Bryan Ingram <https://github/bcingram>
 	Tim Deisser <https://github.com/deisser>
+	Peter Hurtenbach <https://github.com/Peter0x48>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+08/10/2020
+- add new OIDCStateCookiePrefix primitive for the state cookie prefix
+
 08/01/2020
 - add conditional expression to OIDCUnAuthAction; see #479; thanks @raro42 and @marcstern
 - bump to 2.4.4rc6

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -516,6 +516,10 @@
 # When not defined, the default is 7 and "false", thus the oldest cookie(s) will not be deleted.
 #OIDCStateMaxNumberOfCookies <number> [false|true]
 
+# Define the cookie prefix for the state cookie.
+# When not defined the default is "mod_auth_openidc_state_".
+#OIDCStateCookiePrefix <cookie-prefix>
+
 ########################################################################################
 #
 # Session Settings (only relevant in an OpenID Connect Relying Party setup)

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -289,7 +289,7 @@ static char *oidc_get_browser_state_hash(request_rec *r, oidc_cfg *c,
  * return the name for the state cookie
  */
 static char *oidc_get_state_cookie_name(request_rec *r, const char *state) {
-	return apr_psprintf(r->pool, "%s%s", OIDC_STATE_COOKIE_PREFIX, state);
+	return apr_psprintf(r->pool, "%s%s", oidc_cfg_dir_state_cookie_prefix(r), state);
 }
 
 /*
@@ -745,7 +745,7 @@ static int oidc_clean_expired_state_cookies(request_rec *r, oidc_cfg *c,
 		while (cookie != NULL) {
 			while (*cookie == OIDC_CHAR_SPACE)
 				cookie++;
-			if (strstr(cookie, OIDC_STATE_COOKIE_PREFIX) == cookie) {
+			if (strstr(cookie, oidc_cfg_dir_state_cookie_prefix(r)) == cookie) {
 				char *cookieName = cookie;
 				while (cookie != NULL && *cookie != OIDC_CHAR_EQUAL)
 					cookie++;

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -164,9 +164,6 @@ APLOG_USE_MODULE(auth_openidc);
 #define OIDC_AUTH_REQUEST_METHOD_GET  0
 #define OIDC_AUTH_REQUEST_METHOD_POST 1
 
-/* prefix of the cookie that binds the state in the authorization request/response to the browser */
-#define OIDC_STATE_COOKIE_PREFIX  "mod_auth_openidc_state_"
-
 /* default prefix for information passed in HTTP headers */
 #define OIDC_DEFAULT_HEADER_PREFIX "OIDC_"
 
@@ -727,6 +724,7 @@ const char *oidc_cfg_claim_prefix(request_rec *r);
 int oidc_cfg_max_number_of_state_cookies(oidc_cfg *cfg);
 int oidc_cfg_dir_refresh_access_token_before_expiry(request_rec *r);
 int oidc_cfg_dir_logout_on_error_refresh(request_rec *r);
+char *oidc_cfg_dir_state_cookie_prefix(request_rec *r);
 int oidc_cfg_delete_oldest_state_cookies(oidc_cfg *cfg);
 void oidc_cfg_provider_init(oidc_provider_t *provider);
 


### PR DESCRIPTION
Hi,

I added this config setting to enable the definition of the state cookie prefix. The main reason for me was the possible information disclosure when using this mod because someone could immediately see the mod name on the first call to a protected resource.

I added my changes according to the position in the config that was last defined (redirect_urls_allowed) and not related to the other cookie settings, I do not know what you prefer.

What do you think?

Regards,
Peter