### PR TITLE
mod_auth_openidc.c: perform authentication for sub-requests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,3 +64,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Bryan Ingram <https://github/bcingram>
 	Tim Deisser <https://github.com/deisser>
 	Peter Hurtenbach <https://github.com/Peter0x48>
+	Paul Spangler <https://github.com/spanglerco>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+09/19/2020
+- enable authentication of sub-requests when the main request doesn't require
+  authentication; thanks @spanglerco
+
 09/03/2020
 - add SameSite attribute on cookie clearance / logout; thanks @v0gler
 - bump to 2.4.4.1


### PR DESCRIPTION
Fixes the issue described in https://groups.google.com/forum/#!topic/mod_auth_openidc/ghZzUXG_ggY

When Apache performs a sub-request from a route that doesn't require authentication (e.g. `Require all granted`) to one that requires authentication (e.g. `Require valid-user`), mod_auth_openidc was skipping the authentication step. This change inverts the `if (ap_is_initial_req(r))` to run what used to be the else case first. Then we run the code that attempts to authenticate whether we're on a sub-request or not.

Other than reordering the code and changing the if-else, the only other changes were to comments.

## Testing

- `make test` passes
- Created a test conf:
	```apache
	OIDCCryptoPassphrase ...
	OIDCRedirectURI /oidctest/restricted/redirect
	OIDCProviderMetadataURL https://accounts.google.com/.well-known/openid-configuration
	OIDCClientID ...
	OIDCClientSecret ...
	OIDCScope "openid email profile"

	<Directory /var/www/html/oidctest>
		AuthType openid-connect
		Header set Cache-Control no-store
		RewriteEngine On
		RewriteRule ^index.html$ restricted/subreq.html
	</Directory>

	<Directory /var/www/html/oidctest/restricted>
		Require valid-user
	</Directory>
	```
- Without this change, making a request to /oidctest/ redirects to Google and then back even if I'm already logged in:
    ```text
    x.x.x.x - - [18/Sep/2020:11:13:25 -0500] "GET /oidctest/ HTTP/1.1" 302 1920 "-" "Mozilla/5.0 ..."
    x.x.x.x - x@accounts.google.com [18/Sep/2020:11:13:26 -0500] "GET /oidctest/restricted/redirect?state=... HTTP/1.1" 302 896 "-" "Mozilla/5.0 ..."
    x.x.x.x - x@accounts.google.com [18/Sep/2020:11:13:27 -0500] "GET /oidctest/restricted/subreq.html HTTP/1.1" 200 446 "-" "Mozilla/5.0 ..."
    x.x.x.x - - [18/Sep/2020:11:13:38 -0500] "GET /oidctest/ HTTP/1.1" 302 1919 "-" "Mozilla/5.0 ..."
    x.x.x.x - x@accounts.google.com [18/Sep/2020:11:13:39 -0500] "GET /oidctest/restricted/redirect?state=... HTTP/1.1" 302 896 "-" "Mozilla/5.0 ..."
    x.x.x.x - x@accounts.google.com [18/Sep/2020:11:13:39 -0500] "GET /oidctest/restricted/subreq.html HTTP/1.1" 200 446 "-" "Mozilla/5.0 ..."
    ```
- With this change, making a request to /oidctest/ successfully returns the restricted content if I'm already logged in:
    ```text
    x.x.x.x - - [18/Sep/2020:11:50:47 -0500] "GET /oidctest/ HTTP/1.1" 302 1919 "-" "Mozilla/5.0 ..."
    x.x.x.x - x@accounts.google.com [18/Sep/2020:11:50:48 -0500] "GET /oidctest/restricted/redirect?state=... HTTP/1.1" 302 896 "-" "Mozilla/5.0 ..."
    x.x.x.x - x@accounts.google.com [18/Sep/2020:11:50:49 -0500] "GET /oidctest/restricted/subreq.html HTTP/1.1" 200 446 "-" "Mozilla/5.0 ..."
    x.x.x.x - x@accounts.google.com [18/Sep/2020:11:50:56 -0500] "GET /oidctest/ HTTP/1.1" 200 447 "-" "Mozilla/5.0 ..."
    ```