### PR TITLE
mod_auth_openidc.c: set r->ap_auth_type when handling auth

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+09/21/2020
+- populate AUTH_TYPE when performing authentication; thanks @spanglerco
+
 09/19/2020
 - enable authentication of sub-requests when the main request doesn't require
   authentication; thanks @spanglerco


### PR DESCRIPTION
Apache expects mod_auth_* modules to populate r->ap_auth_type to server as the source of the AUTH_TYPE CGI variable. This allows content or other modules to detect the authentication source for the request. I applied the common idiom that can be found in mod_auth_basic and mod_auth_form, which is to save the result of `ap_auth_type(r)` to a variable and use that in the `r->ap_auth_type` assignment. But in mixed mode, it assigns r->ap_auth_type to whichever type is actually in use.

## Testing

- `make test` passes
- Created a test conf:
	```apache
	OIDCCryptoPassphrase ...
	OIDCRedirectURI /oidctest/restricted/redirect
	OIDCProviderMetadataURL https://accounts.google.com/.well-known/openid-configuration
	OIDCClientID ...
	OIDCClientSecret ...
	OIDCScope "openid email profile"

	<Directory /var/www/html/oidctest>
		AuthType auth-openidc
		Header set Cache-Control no-store
		Require valid-user
		Options +Includes
		AddType text/html .shtml
		AddOutputFilter INCLUDES .shtml
		DirectoryIndex index.shtml
	</Directory>
	```
- Created a simple index.shtml:
    ```html
    <!DOCTYPE html>
    <title>Hello from index</title>
    <h1>Hello from index</h1>
    <p>Your REMOTE_USER is '<!--#echo encoding="entity" var="REMOTE_USER" -->'.</p>
    <p>Your AUTH_TYPE is '<!--#echo encoding="entity" var="AUTH_TYPE" -->'.</p>
    ```
- Without this change, making a request to /oidctest/ results in this output:
    ```text
    Your AUTH_TYPE is '(none)'.
    ```
- With this change, making a request to /oidctest/ successfully populates AUTH_TYPE:
    ```text
    Your AUTH_TYPE is 'openid-connect'.
    ```
- I also verified the correct AUTH_TYPE when using `AuthType openid-connect` instead of mixed mode.