### PR TITLE
Make CA Bundle Path configurable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Tim Deisser <https://github.com/deisser>
 	Peter Hurtenbach <https://github.com/Peter0x48>
 	Paul Spangler <https://github.com/spanglerco>
+	Chris Pawling <https://github.com/chris468>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+10/08/2020
+- add OIDCCABundlePath for configuring path to curl CA bundle
+
 09/21/2020
 - populate AUTH_TYPE when performing authentication; thanks @spanglerco
 

--- a/src/config.c
+++ b/src/config.c
@@ -277,6 +277,7 @@
 #define OIDCStateInputHeaders                  "OIDCStateInputHeaders"
 #define OIDCRedirectURLsAllowed                "OIDCRedirectURLsAllowed"
 #define OIDCStateCookiePrefix                  "OIDCStateCookiePrefix"
+#define OIDCCABundlePath                       "OIDCCABundlePath"
 
 extern module AP_MODULE_DECLARE_DATA auth_openidc_module;
 
@@ -1343,6 +1344,8 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 
 	c->redirect_urls_allowed = NULL;
 
+	c->ca_bundle_path = NULL;
+
 	return c;
 }
 
@@ -1817,6 +1820,10 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 	c->redirect_urls_allowed =
 			add->redirect_urls_allowed != NULL ?
 					add->redirect_urls_allowed : base->redirect_urls_allowed;
+
+	c->ca_bundle_path =
+			add->ca_bundle_path != NULL ?
+					add->ca_bundle_path : base->ca_bundle_path;
 
 	return c;
 }
@@ -3246,6 +3253,12 @@ const command_rec oidc_config_cmds[] = {
 				(void *) APR_OFFSETOF(oidc_dir_cfg, state_cookie_prefix),
 				RSRC_CONF|ACCESS_CONF|OR_AUTHCFG,
 				"Define the cookie prefix for the state cookie."),
+
+		AP_INIT_TAKE1(OIDCCABundlePath,
+				oidc_set_string_slot,
+				(void *) APR_OFFSETOF(oidc_cfg, ca_bundle_path),
+				RSRC_CONF,
+				"Sets the path to the CA bundle to be used by cURL."),
 
 		{ NULL }
 };

--- a/src/config.c
+++ b/src/config.c
@@ -417,6 +417,16 @@ static const char *oidc_set_dir_slot(cmd_parms *cmd, void *ptr, const char *arg)
 }
 
 /*
+ * set a path value in the server config, converting to absolute if necessary
+ */
+static const char *oidc_set_path_slot(cmd_parms *cmd, void *ptr, const char *arg) {
+	oidc_cfg *cfg = (oidc_cfg *) ap_get_module_config(
+			cmd->server->module_config, &auth_openidc_module);
+	const char *full_path = oidc_util_get_full_path(cmd->pool, arg);
+	return ap_set_string_slot(cmd, cfg, full_path);
+}
+
+/*
  * set the cookie domain in the server config and check it syntactically
  */
 static const char *oidc_set_cookie_domain(cmd_parms *cmd, void *ptr,
@@ -3255,7 +3265,7 @@ const command_rec oidc_config_cmds[] = {
 				"Define the cookie prefix for the state cookie."),
 
 		AP_INIT_TAKE1(OIDCCABundlePath,
-				oidc_set_string_slot,
+				oidc_set_path_slot,
 				(void *) APR_OFFSETOF(oidc_cfg, ca_bundle_path),
 				RSRC_CONF,
 				"Sets the path to the CA bundle to be used by cURL."),

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -426,6 +426,8 @@ typedef struct oidc_cfg {
 	apr_byte_t state_input_headers;
 
 	apr_hash_t *redirect_urls_allowed;
+
+	char *ca_bundle_path;
 } oidc_cfg;
 
 int oidc_check_user_id(request_rec *r);


### PR DESCRIPTION
Added a configuration option to specify the path of the CA Bundle for curl
Fixes #329 

### Testing
- `make test` passes
- I can log in with google without specifying a CA bundle path
- I can log with a locally hosted OpenID Connect server that uses a certificate signed by a test CA when I specify a bundle path containing the test CA:
    `OIDCCABundlePath "/path/to/my/bundle.crt"`
    with both absolute and relative paths