### PR TITLE
session.c: Delete session cookies that fail to load

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+10/19/2020
+- delete stale session cookies that aren't in the cache
+
 10/08/2020
 - add OIDCCABundlePath for configuring path to curl CA bundle
 

--- a/src/session.c
+++ b/src/session.c
@@ -180,7 +180,7 @@ static apr_byte_t oidc_session_load_cache(request_rec *r, oidc_session_t *z) {
 
 		rc = oidc_session_load_cache_by_uuid(r, c, uuid, z);
 
-		if (rc == FALSE) {
+		if (rc == FALSE || z->state == NULL) {
 			/* delete the session cookie */
 			oidc_util_set_cookie(r, oidc_cfg_dir_cookie(r), "", 0,
 					OIDC_COOKIE_EXT_SAME_SITE_NONE);


### PR DESCRIPTION
Session cookies are deleted when the session fails to load, but not in the case where there is a cache miss. For example, restarting the web server when using a non-persistent cache like shm will clear all sessions, but clients may continue to have session cookies. This change allows the session cookie to be deleted on cache misses as well.

An example use case is to support OIDC and mod_auth_form side-by-side, using the existence of the session cookie to know which AuthType to enable.

## Testing

- `make test` passes
- Created a bogus session cookie in my browser. With a single OIDC provider (Google) configured, I made a request to a protected URL and verified the session cookie was deleted at the same time the state cookie was created during redirect to Google. Redirecting back to Google correctly set a new session cookie.
- Created a bogus session cookie in my browser. With multiple providers configured, I made a request to a protected URL and verified the session cookie was deleted at the same time I was redirected to the discovery page.