### PR TITLE
config.c: Add exec support to OIDCCryptoPassphrase

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 10/22/2019
 - hash define expression option to OIDCUnAuthAction so it compiles for Apache 2.2; fixes 1461634
 - bump to 2.4.5rc1
+- add exec support to OIDCCryptoPassphrase
  
 10/19/2020
 - delete stale session cookies that aren't in the cache

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -17,7 +17,11 @@
 # - encryption of the (temporary) state cookie
 # - encryption of cache entries, that may include the session cookie, see: OIDCCacheEncrypt and OIDCSessionType
 # Note that an encrypted cache mechanism can be shared between servers if they use the same OIDCCryptoPassphrase
+# If the value begins with exec: the resulting command will be executed and the
+# first line returned to standard output by the program will be used as the
+# password. The command may be absolute or relative to the web server root.
 #OIDCCryptoPassphrase <passphrase>
+#OIDCCryptoPassphrase "exec:/path/to/otherProgram argument1"
 
 #
 # All other entries below this are optional though some may be required in a

--- a/test/stub.c
+++ b/test/stub.c
@@ -37,6 +37,11 @@ AP_DECLARE(long) ap_get_client_block(request_rec * r, char * buffer,
 	return 0;
 }
 
+AP_DECLARE(char *) ap_get_exec_line(apr_pool_t *p, const char *cmd,
+		const char * const *argv) {
+	return NULL;
+}
+
 AP_DECLARE(char *) ap_getword(apr_pool_t *atrans, const char **line, char stop) {
 	const char *pos = *line;
 	int len;


### PR DESCRIPTION
Similar to mod_session_crypto's [SessionCryptoPassphrase](https://httpd.apache.org/docs/2.4/mod/mod_session_crypto.html#sessioncryptopassphrase) and mod_ssl's [SSLPassPhraseDialog](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslpassphrasedialog), this adds the ability for OIDCCryptoPassphrase to reference an executable whose output becomes the passphrase. This enables passphrase rotation (per server start) and/or the ability to not hard-code a passphrase into the conf file.

## Testing

- `make test` passes
- In a conf file, put `OIDCCryptoPassphrase secret` and verified using a debugger that "secret" is the passphrase being used
- In a conf file, put `OIDCCryptoPassphrase "exec:openssl rand -base64 32"` and verified using a debugger that the passphrase was a random base64 string