### PR TITLE
Remove session from cache before clearing it.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,3 +67,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Paul Spangler <https://github.com/spanglerco>
 	Chris Pawling <https://github.com/chris468>
 	Matthias Fleschütz <https://github.com/blindzero>
+	Harri Rautila <https://github.com/hrautila>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+02/16/2021
+- remove session from cache before clearing it.
+
 02/12/2021
 - add maximum session lifetime (exp), inactivity timeout (timeout) and remote_user to OIDCInfoHook
 - bump to 2.4.7-dev

--- a/src/session.c
+++ b/src/session.c
@@ -398,8 +398,12 @@ apr_byte_t oidc_session_free(request_rec *r, oidc_session_t *z) {
  * terminate a session
  */
 apr_byte_t oidc_session_kill(request_rec *r, oidc_session_t *z) {
-	oidc_session_free(r, z);
-	return oidc_session_save(r, z, FALSE);
+	if (z->state) {
+		json_decref(z->state);
+		z->state = NULL;
+	}
+	oidc_session_save(r, z, FALSE);
+	return oidc_session_free(r, z);
 }
 
 /*


### PR DESCRIPTION
Hi,
We noticed that after logout we were able to make successful API calls with a saved session cookie. After some testing and reading debug logs we found following lines in the log to be of suspect.

src/util.c(2413):  oidc_util_hdr_err_out_add: Set-Cookie: <AccessName>=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None
src/cache/common.c(640):  oidc_cache_set: enter:  (section=s, len=0, encrypt=0, ttl(s)=-1613130005, type=shm)
src/cache/common.c(668):  oidc_cache_set: successfully stored 0 bytes in shm cache backend for key 

The session cookie was cleared from the client but deleting the cache entry seemed to fail. This PR is a suggestion to remedy the situation. After this change we can see following log lines and access with saved session cookie fails.

src/cache/common.c(643):  oidc_cache_set: enter: 4330eb78-0176-4608-907d-ab7df74d2491 (section=s, len=0, encrypt=0, ttl(s)=-1613472125, type=shm)
src/cache/common.c(671):  oidc_cache_set: successfully stored 0 bytes in shm cache backend for key 4330eb78-0176-4608-907d-ab7df74d2491

