### PR TITLE
Update proto.c

### DIFF
--- a/src/proto.c
+++ b/src/proto.c
@@ -1734,7 +1734,7 @@ static apr_byte_t oidc_proto_endpoint_client_secret_basic(request_rec *r,
 	}
 	*basic_auth_str = apr_psprintf(r->pool, "%s:%s",
 			oidc_util_escape_string(r, client_id),
-			oidc_util_escape_string(r, client_secret));
+			client_secret);
 
 	return TRUE;
 }


### PR DESCRIPTION
 If you have special characters in OIDCClientSecret, oidc_util_escape_string method seem change it with url encoding (Example: '+' change to %2B).