### PR TITLE
Add support for ipv6

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,4 +70,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Harri Rautila <https://github.com/hrautila>
 	Tatsuhiko Yasumatsu <https://github.com/ty60>
 	Adam Stadler <https://github.com/tzfx>
-    Steffen Greber <https://github.com/codemaker219>
+	Steffen Greber <https://github.com/codemaker219>

--- a/AUTHORS
+++ b/AUTHORS
@@ -70,3 +70,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Harri Rautila <https://github.com/hrautila>
 	Tatsuhiko Yasumatsu <https://github.com/ty60>
 	Adam Stadler <https://github.com/tzfx>
+    Steffen Greber <https://github.com/codemaker219>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+06/04/2021
+- fix a problem where the host and port are calculated incorrectly, when you use literal ipv6 address.
+
 06/02/2021
 - do not send state timeout HTML document when OIDCDefaultURL is set; this can be overridden by using e.g.:
   SetEnvIfExpr true OIDC_NO_DEFAULT_URL_ON_STATE_TIMEOUT=true 

--- a/test/test.c
+++ b/test/test.c
@@ -1285,6 +1285,16 @@ static char * test_current_url(request_rec *r) {
 	TST_ASSERT_STR("test_current_url (8)", url,
 			"http://remotehost:8380/private/?foo=bar&param1=value1");
 
+	apr_table_set(r->headers_in, "Host", "[fd04:41b1:1170:28:16b0:446b:9fb7:7118]:8380");
+	url = oidc_get_current_url(r);
+	TST_ASSERT_STR("test_current_url (9)", url,
+			"http://[fd04:41b1:1170:28:16b0:446b:9fb7:7118]:8380/private/?foo=bar&param1=value1");
+
+	apr_table_set(r->headers_in, "Host", "[fd04:41b1:1170:28:16b0:446b:9fb7:7118]");
+	url = oidc_get_current_url(r);
+	TST_ASSERT_STR("test_current_url (10)", url,
+			"http://[fd04:41b1:1170:28:16b0:446b:9fb7:7118]/private/?foo=bar&param1=value1");
+
 	return 0;
 }
 


### PR DESCRIPTION
Hi,
I added support for ipv6. If you tried to access the apache with an ipv6 address like `http://[fd04:41b1:1170:28:16b0:446b:9fb7:7118]:8380` the calculated port and host are incorrect.