### PR TITLE
Remove call to apr_table_clear() to resolve issue with missing client_id on access token revoke.

### DIFF
--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -2640,7 +2640,6 @@ static void oidc_revoke_tokens(request_rec *r, oidc_cfg *c,
 				NULL, NULL) == FALSE) {
 			oidc_warn(r, "revoking refresh token failed");
 		}
-		apr_table_clear(params);
 	}
 
 	token = oidc_session_get_access_token(r, session);

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -2644,8 +2644,8 @@ static void oidc_revoke_tokens(request_rec *r, oidc_cfg *c,
 
 	token = oidc_session_get_access_token(r, session);
 	if (token != NULL) {
-		apr_table_addn(params, "token_type_hint", "access_token");
-		apr_table_addn(params, "token", token);
+		apr_table_setn(params, "token_type_hint", "access_token");
+		apr_table_setn(params, "token", token);
 
 		if (oidc_util_http_post_form(r, provider->revocation_endpoint_url,
 				params, basic_auth, bearer_auth, c->oauth.ssl_validate_server,


### PR DESCRIPTION
Remove call to apr_table_clear() to avoid dropping the 'client_id' and
'client_secret' parameters before revoking the access token. This
ensures that when the client_secret_post authentication method is used
the required data parameters are sent when revoking both the refresh
and access tokens.