### PR TITLE
Do not delete the session cookie in the event of a cache backend failure

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+08/18/2021
+- preserve session cookie in the event of a cache backend failure
+
 08/13/2021
 - fix retried Redis commands after a reconnect; thanks @iainh
 - release 2.4.9.1

--- a/src/session.c
+++ b/src/session.c
@@ -169,7 +169,14 @@ static apr_byte_t oidc_session_load_cache(request_rec *r, oidc_session_t *z) {
 
 		rc = oidc_session_load_cache_by_uuid(r, c, uuid, z);
 
-		if (rc == FALSE || z->state == NULL) {
+		/* cache backend experienced an error while attempting lookup */
+		if (rc == FALSE) {
+			oidc_error(r, "cache backend failure for key %s", uuid);
+			return FALSE;
+		}
+
+		/* cache backend does not contain an entry for the given key */
+		if (z->state == NULL) {
 			/* delete the session cookie */
 			oidc_util_set_cookie(r, oidc_cfg_dir_cookie(r), "", 0,
 					OIDC_COOKIE_EXT_SAME_SITE_NONE(r));


### PR DESCRIPTION
The cache backend will always return TRUE in the event of a
authoritative cache hit or miss. FALSE is returned only in cases where
the cache backend is unable answer the query or mod_auth_openidc is
unable to grab a global lock. By not deleting the session cookie in the
cases where the backend has failed, we allow clients to gracefully
resume once the backend is restored.