### PR TITLE
 When refreshing the access token, update the id_token if possible

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 08/18/2021
 - preserve session cookie in the event of a cache backend failure
+- update the id_token in the session cache if one is provided while refreshing the access token
 
 08/13/2021
 - fix retried Redis commands after a reconnect; thanks @iainh


### PR DESCRIPTION
When sending a request to refresh the access token, it is possible that
the response will contain a new id_token. If it does, update the id_token
JWT and claims in the session as well the maximum session duration if
OIDCSessionMaxDuration is 0.