### PR TITLE
Use optionally provided sid and iss request parameters during front channel logout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,3 +83,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Daan Bakker <https://github.com/dbakker>
 	smanolache <https://github.com/smanolache>
 	blackwhiser1 <https://github.com/blackwhiser1>
+	Ruediger Pluem <https://github.com/rpluem-vf>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+05/16/2022
+- Use optionally provided sid and iss request parameters during front channel
+  logout; see #855; thanks @rpluem-vf
+
 05/06/2022
 - support Forwarded header in addition to X-Forwarded-*; see #853; thanks @studersi
 - bump to 2.4.11.3rc0

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -482,6 +482,8 @@ apr_byte_t oidc_get_remote_user(request_rec *r, const char *claim_name, const ch
 #define OIDC_REDIRECT_URI_REQUEST_REMOVE_AT_CACHE  "remove_at_cache"
 #define OIDC_REDIRECT_URI_REQUEST_REVOKE_SESSION   "revoke_session"
 #define OIDC_REDIRECT_URI_REQUEST_REQUEST_URI      "request_uri"
+#define OIDC_REDIRECT_URI_REQUEST_SID              "sid"
+#define OIDC_REDIRECT_URI_REQUEST_ISS              "iss"
 
 // oidc_oauth
 int oidc_oauth_check_userid(request_rec *r, oidc_cfg *c, const char *access_token);


### PR DESCRIPTION
Use optionally provided `sid` and `iss` request parameters by the OP during front channel logout as specified in [OpenID Connect Front-Channel Logout 1.0 - draft 05](https://openid.net/specs/openid-connect-frontchannel-1_0.html) to remove the session from cache in case no session was provided via cookie in the request which is the default for a front channel logout with `SameSite` setting of `lax` or `strict` for the session cookie.