### PR TITLE
fix for ipv6 hosts if logout url is set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+05/19/2022
+- fix a issue if a provided logout url has a ipv6 address as host
+
 05/16/2022
 - Use optionally provided sid and iss request parameters during front channel
   logout; see #855; thanks @rpluem-vf


### PR DESCRIPTION
Fix for a ipv6 issue. If you use a Ipv6 host and want to logout followed by a redirect, you can use something like https://192.168.28.218/redirect_uri?logout=https://192.168.28.218. This is not working with ipv6 addresses like https://[fe80::3b8:df66:1dc3:f797]/redirect_uri?logout=https://[fe80::3b8:df66:1dc3:f797]

The reason is that we take `uri.hostname`  into account here and want to have `c_host` containg it. But `c_host` would be for this example `[fe80::3b8:df66:1dc3:f797]` but the `uri.hostname` is `fe80::3b8:df66:1dc3:f797` (missing `[` and `]`). So we need to handle ipv6 addresses differently.
