### PR TITLE
Escape periods in regular expressions for OIDCRedirectURLsAllowed documentation.

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -944,9 +944,9 @@
 # other redirects such as the "return_to" value on refresh token requests, the "login_uri" value
 # on session management based logins through the OP iframe, and the "target_link_uri" parameter in
 # 3rd-party initiated logins, e.g.:
-#   OIDCRedirectURLsAllowed ^https://www.example.com ^https://(\w+).example.org ^https://example.net/app
+#   OIDCRedirectURLsAllowed ^https://www\.example\.com ^https://(\w+)\.example\.org ^https://example\.net/app
 # or:
-#   OIDCRedirectURLsAllowed ^https://www.example.com/logout$ ^https://www.example.com/app/return_to$ 
+#   OIDCRedirectURLsAllowed ^https://www\.example\.com/logout$ ^https://www\.example\.com/app/return_to$
 # When not defined, the default is to match the hostname in the URL redirected to against
 # the hostname in the current request.
 #OIDCRedirectURLsAllowed [<regexp>]+


### PR DESCRIPTION
The regexes currently used to describe the behaviour of the `OIDCRedirectURLsAllowed` directive contain unescaped periods. This can lead to redirects being less restricted than intended.

For example, with the configuration
```
OIDCRedirectURLsAllowed ^https://www.example.com ^https://(\w+).example.org ^https://example.net/app
```
a redirect to `https://wwwXexample.com` would not be blocked by `mod_auth_openidc`, whereas the following configuration would block such a redirect:
```
OIDCRedirectURLsAllowed ^https://www\.example\.com ^https://(\w+)\.example\.org ^https://example\.net/app
```

Aside from the updated regexes, would it be sensible to add a warning for this in the documentation? This is a very common pitfall when restricting URLs with regexes.