### PR TITLE
Allow setting connection pool parameters for Memcache server connections

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
 - apply exact length matching for at_hash and c_hash validation; for certification purposes
 - increase size of the output buffer when using libpcre2 for substitution; closes #915
 - bump to 2.4.11.4rc2
+- allow setting connection pool parameters for Memcache server connections;
+  see #???; thanks @rpluem-vf
 
 08/24/2022
 - avoid using $< in Makefile

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,7 @@
 - increase size of the output buffer when using libpcre2 for substitution; closes #915
 - bump to 2.4.11.4rc2
 - allow setting connection pool parameters for Memcache server connections;
-  see #???; thanks @rpluem-vf
+  see #916; thanks @rpluem-vf
 
 08/24/2022
 - avoid using $< in Makefile

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -632,6 +632,24 @@
 # Specifies the memcache servers used for caching as a space separated list of <hostname>[:<port>] tuples.
 #OIDCMemCacheServers "(<hostname>[:<port>])+"
 
+# Minimum number of connections to each Memcache server per process. Defaults to
+# OIDCMemCacheConnectionsHMax.
+#OIDCMemCacheConnectionsMin <number>
+
+# All connections above this limit will be closed if they have been idle for
+# more than OIDCMemCacheConnectionsTTL. Defaults to OIDCMemCacheConnectionsHMax.
+#OIDCMemCacheConnectionsSMax <number>
+
+# Maximum number of connections to each Memcache server per process. Defaults to
+# ThreadsPerChild or if mod_http2 is loaded to ThreadsPerChild - 1 + H2MaxWorkers.
+#OIDCMemCacheConnectionsHMax <number>
+
+# Maximum time in seconds a connection to a Memcache server can be idle before
+# being closed. Defaults to 60 seconds.
+# Only for Apache >= 2.4.x: By adding a postfix of ms, the timeout can be also
+# set in milliseconds. Defaults to 60 seconds.
+#OIDCMemCacheConnectionsTTL <seconds>
+
 # Required if Redis support is compiled in and when using OIDCCacheType "redis":
 # Specifies the Redis server used for caching as a <hostname>[:<port>] tuple.
 #OIDCRedisCacheServer <hostname>[:<port>]

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -407,6 +407,14 @@ typedef struct oidc_cfg {
 #ifdef USE_MEMCACHE
 	/* cache_type= memcache: list of memcache host/port servers to use */
 	char *cache_memcache_servers;
+	/* cache_type= memcache: minimum number of connections to each memcache server per process*/
+	apr_uint32_t cache_memcache_min;
+	/* cache_type= memcache: soft maximum number of connections to each memcache server per process */
+	apr_uint32_t cache_memcache_smax;
+	/* cache_type= memcache: hard maximum number of connections to each memcache server per process */
+	apr_uint32_t cache_memcache_hmax;
+	/* cache_type= memcache: maximum time in microseconds a connection to a memcache server can be idle before being closed */
+	apr_uint32_t cache_memcache_ttl;
 #endif
 	/* cache_type = shm: size of the shared memory segment (cq. max number of cached entries) */
 	int cache_shm_size_max;
@@ -725,6 +733,10 @@ int oidc_oauth_return_www_authenticate(request_rec *r, const char *error, const 
 #define OIDCOAuthRemoteUserClaim             "OIDCOAuthRemoteUserClaim"
 #define OIDCSessionType                      "OIDCSessionType"
 #define OIDCMemCacheServers                  "OIDCMemCacheServers"
+#define OIDCMemCacheConnectionsMin           "OIDCMemCacheConnectionsMin"
+#define OIDCMemCacheConnectionsSMax          "OIDCMemCacheConnectionsSMax"
+#define OIDCMemCacheConnectionsHMax          "OIDCMemCacheConnectionsHMax"
+#define OIDCMemCacheConnectionsTTL           "OIDCMemCacheConnectionsTTL"
 #define OIDCCacheShmMax                      "OIDCCacheShmMax"
 #define OIDCCacheShmEntrySizeMax             "OIDCCacheShmEntrySizeMax"
 #define OIDCRedisCacheServer                 "OIDCRedisCacheServer"

--- a/test/stub.c
+++ b/test/stub.c
@@ -308,6 +308,21 @@ AP_DECLARE(void) ap_log_error_(const char *file, int line, int module_index,
 			return NULL;
 		}
 
+		AP_DECLARE(apr_status_t) ap_mpm_query(int query_code, int *result) {
+			*result = 1;
+			return APR_SUCCESS;
+		}
+
+#if AP_MODULE_MAGIC_AT_LEAST(20080920, 2)
+		AP_DECLARE(apr_status_t) ap_timeout_parameter_parse(
+                                               const char *timeout_parameter,
+                                               apr_interval_time_t *timeout,
+                                               const char *default_time_unit) {
+			*timeout = 0;
+			return APR_SUCCESS;
+		}
+#endif
+
 #if MODULE_MAGIC_NUMBER_MAJOR >= 20100714
 		AP_DECLARE(int) ap_expr_exec(request_rec *r, const ap_expr_info_t *expr,
 				const char **err) {


### PR DESCRIPTION
* ChangeLog: Document change
* auth_openidc.conf Document the new directives OIDCMemCacheConnectionsMin OIDCMemCacheConnectionsSMax OIDCMemCacheConnectionsHMax OIDCMemCacheConnectionsTTL
* src/cache/memcache.c oidc_cache_memcache_post_config: Use the new parameters or use defaults when calling apr_memcache_server_create
* src/config.c oidc_set_uint32_slot: New function to set an apr_uint32_t value in the server config oidc_set_timeout_slot: New function to set an 32 bit uint timeout slot in the server config oidc_create_server_config: Init additional fields oidc_merge_server_config: Merge additional fields Declare the new directives OIDCMemCacheConnectionsMin OIDCMemCacheConnectionsSMax OIDCMemCacheConnectionsHMax OIDCMemCacheConnectionsTTL
* src/mod_auth_openidc.h Add new fields to struct oidc_cfg
* test/stub.c Add new stubs from httpd API: ap_mpm_query ap_timeout_parameter_parse