### PR TITLE
 Corrected documentation for OIDCPreservePost uses Session Storage

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -889,7 +889,7 @@
 # Indicates whether POST data will be preserved across authentication requests (and discovery in case of multiple OPs).
 # This is designed to prevent data loss when a session timeout occurs in a (long) user filled HTML form.
 # It cannot handle arbitrary payloads for security (DOS) reasons, merely form-encoded user data.
-# Preservation is done via HTML 5 local storage: note that this can lead to private data exposure on shared terminals.
+# Preservation is done via HTML 5 session storage: note that this can lead to private data exposure on shared terminals.
 # The default is "Off" (for security reasons). Can be configured on a per Directory/Location basis.
 #OIDCPreservePost [On|Off]
 


### PR DESCRIPTION
I suggest modifying auth_openidc.conf.