### PR TITLE
Corrected OIDCCookiePath description

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -483,8 +483,9 @@
 #
 ########################################################################################
 
-# Define the cookie path for the "state" and "session" cookies.
+# Define the cookie path for the "session" cookie.
 # When not defined the default is a server-wide "/".
+# Note that the "state" cookie is always set to "/".
 #OIDCCookiePath <cookie-path>
 
 # Specify the domain for which the "state" and "session" cookies will be set.


### PR DESCRIPTION
I suggest modifying auth_openidc.conf.

I expected state and session cookies to have a Path attribute by setting OIDCCookiePath, but it had no effect on the state cookie.